### PR TITLE
Second Order BDIM and general overhaul

### DIFF
--- a/examples/ThreeD_TaylorGreenVortex.jl
+++ b/examples/ThreeD_TaylorGreenVortex.jl
@@ -11,7 +11,7 @@ function TGV_video(p=6,Re=1e5,Δprint=0.1,nprint=100)
     L = 2^p; U = 1; ν = U*L/Re
 
     # Taylor-Green-Vortex initial velocity field
-    u = apply(L+2,L+2,L+2,3) do i,vx
+    function uλ(i,vx)
         x,y,z = @. (vx-1.5)*π/L                # scaled coordinates
         i==1 && return -U*sin(x)*cos(y)*cos(z) # u_x
         i==2 && return  U*cos(x)*sin(y)*cos(z) # u_y
@@ -19,10 +19,7 @@ function TGV_video(p=6,Re=1e5,Δprint=0.1,nprint=100)
     end
 
     # Initialize simulation
-    c = ones(L+2,L+2,L+2,3)  # no immersed solids
-    a = Flow(u,c,zeros(3),ν=ν)
-    b = MultiLevelPoisson(c)
-    sim = Simulation(U,L,a,b)
+    sim = Simulation((L+2,L+2,L+2),zeros(3),L;uλ,ν)
 
     # plot the vorticity modulus
     scene = Scene(backgroundcolor = :black)

--- a/examples/ThreeD_donut.jl
+++ b/examples/ThreeD_donut.jl
@@ -2,23 +2,21 @@ using WaterLily
 using LinearAlgebra: norm2
 using Makie
 
-function donut_sim(p=6,Re=1e3)
-    # Define simulation size, velocity, viscosity
-    n,U = 2^p, [1, 0, 0]
+function donut_sim(;p=6,Re=1e3)
+    # Define simulation size, geometry dimensions, viscosity
+    n = 2^p
     center,R,r = [n/2,n/2,n/2], n/4, n/16
-    ν = norm2(U)*R/Re
+    ν = R/Re
+    @show R,ν
 
     # Apply signed distance function for a torus
-    c = BDIM_coef(2n+2,n+2,n+2,3) do xyz  #
+    body = AutoBody() do xyz,t
         x,y,z = xyz - center
         norm2([x,norm2([y,z])-R])-r
     end
 
-    # Initialize Flow, Poisson and make struct
-    u = zeros(2n+2,n+2,n+2,3)
-    a = Flow(u,c,U,ν=ν)
-    b = MultiLevelPoisson(c)
-    Simulation(norm2(U),R,a,b),center
+    # Initialize simulation
+    Simulation((2n+2,n+2,n+2),[1.,0.,0.],R;ν,body),center
 end
 
 function flowdata(sim)

--- a/examples/TwoD_Julia.jl
+++ b/examples/TwoD_Julia.jl
@@ -2,7 +2,7 @@ using WaterLily
 using LinearAlgebra: norm2
 include("TwoD_plots.jl")
 
-function TwoD_julia_video(p=6,Re=250)
+function TwoD_julia_video(;p=6,Re=250,stop=60.)
     # Set simulation size & physical parameters
     n,m = 2^p,2^p
     U,R,r = [0.,-1.], m/16, m/16/0.75
@@ -10,36 +10,30 @@ function TwoD_julia_video(p=6,Re=250)
     @show R,ν
 
     # Immerse three well placed circles (change for other shapes)
+    z = [R*exp(im*θ) for θ ∈ range(0,2π,length=33)]
     centers = [n/2+im*3*m/4+r*exp(im*ϕ) for ϕ ∈ [π/2,π/2+2π/3,π/2-2π/3]]
     colors = [:forestgreen,:brown3,:mediumorchid3]
-
-    c = BDIM_coef(n+2,m+2,2) do xy  # signed distance function
+    body = AutoBody() do x,t  # signed distance function
             minimum(centers) do center
-                norm2(complex(xy...) - center) - R
+                norm2(complex(x...) - center) - R
             end
     end
 
-    # Initialize flow and Poisson system
-    u = zeros(n+2,m+2,2); BC!(u,U)
-    a = Flow(u,c,U,ν=ν);
-    b = MultiLevelPoisson(c)
+    # Initialize simulation
+    sim = Simulation((n+2,m+2),U,R;ν,body)
 
-    # Evolve solution in time and plot to a gif
-    tprint,Δprint,nprint = 0.0,0.3,200
+    # Solve flow and make nice gif
+    t = range(0.,stop;step=0.3)
     gr(show = false, size=(700,600))
-    @time @gif for i ∈ 1:nprint
-        while tprint<0
-            mom_step!(a,b)
-            tprint += a.Δt[end]*norm2(U)/R
-        end
-        @inside a.σ[I]=WaterLily.curl(3,I,a.u)*R/norm2(U)
-        flood(a.σ,shift=(-0.5,-0.5),clims=(-5,5),
+    @time @gif for tᵢ in t
+        println("tU/L=",round(tᵢ,digits=4))
+        sim_step!(sim,tᵢ)
+        @inside sim.flow.σ[I] = WaterLily.curl(3,I,sim.flow.u)*sim.L/sim.U
+        flood(sim.flow.σ,shift=(-0.5,-0.5),clims=(-5,5),
             cfill=:Blues,legend=false,border=:none)
         for (center,color) ∈ zip(centers,colors)
-            z = [R*exp(im*θ)+center for θ ∈ range(0,2π,length=33)]
-            addbody(real(z),imag(z),c=color)
+            addbody(real(z+center),imag(z+center),c=color)
         end
-        tprint-=Δprint
     end
-    return a
+    return sim
 end

--- a/examples/TwoD_SmoothLivePlot.jl
+++ b/examples/TwoD_SmoothLivePlot.jl
@@ -1,25 +1,8 @@
 using WaterLily
 using LinearAlgebra: norm2
 include("TwoD_plots.jl")
+include("TwoD_circle.jl")
 using SmoothLivePlot
-
-function circle(n,m;Re=250)
-    # Set physical parameters
-    U,R,center = 1., m/8., [m/2,m/2]
-    ν=U*R/Re
-    @show R,ν
-
-    # Immerse a circle (change for other shapes)
-    c = BDIM_coef(n+2,m+2,2) do xy
-        norm2(xy .- center) - R  # signed distance function
-    end
-
-    # Initialize Simulation object
-    u = zeros(n+2,m+2,2)
-    a = Flow(u,c,[U,0.],ν=ν)
-    b = MultiLevelPoisson(c)
-    Simulation(U,R,a,b)
-end
 
 function v_plot(t,v,i=length(t))
     sleep(0.001)

--- a/examples/TwoD_block.jl
+++ b/examples/TwoD_block.jl
@@ -1,41 +1,20 @@
 using WaterLily
+using LinearAlgebra: norm2
 include("TwoD_plots.jl")
 
-function TwoD_block_video(p,Re=250)
-    # Set simulation size & physical parameters
-    n,m = 2^p,2^(p-1)
-    U,L = [1.,0.],m/4.; ν=U[1]*L/Re
+function block(m;Re=250)
+    # Set physical parameters
+    U,L,center = 1., m/4., [m/2+0.5,m/2]
+    ν=U*L/Re
     @show L,ν
 
-    # Initialize uniform fields
-    u = zeros(n+2,m+2,2); BC!(u,U)
-    c = ones(n+2,m+2,2); BC!(c,[0. 0.])
-    ω₃ = zeros(n,m)
-
-    # Immerse a solid block over an x,y range
-    xr,yr = m÷2:m÷2+1,3m÷8+2:5m÷8+1;
-    u[xr[1]:xr[end]+1,yr,1] .= 0
-    c[xr[1]:xr[end]+1,yr,1] .= 0
-    c[xr,yr[1]:yr[end]+1,2] .= 0
-    x = [xr[1],xr[end],xr[end],xr[1],xr[1]]
-    y = [yr[1],yr[1],yr[end],yr[end],yr[1]]
-
-    # Initialize flow and Poisson system
-    a = Flow(u,c,U,ν=ν);
-    b = MultiLevelPoisson(a.μ₀)
-
-    # Evolve solution in time and plot to a gif
-    tprint,Δprint,nprint = -30.,0.25,100
-    gr(show = false, size=(780,360))
-    @time @gif for i ∈ 1:nprint
-        while tprint<0
-            mom_step!(a,b)
-            tprint += a.Δt[end]*U[1]/L
-        end
-        @inside ω₃[I]=WaterLily.curl(3,I,a.u)*L/U[1]
-        flood(ω₃,shift=(-0.5,-0.5),clims=(-16,16))
-        addbody(x,y)
-        tprint-=Δprint
+    # block geometry
+    body = AutoBody() do x,t
+        x .-= center
+        x[2] -= clamp(x[2],-L/2,L/2)
+        norm2(x)-1
     end
-    return a
+
+    Simulation((2m+2,m+2),[U,0.],L;body,ν)
 end
+sim_gif!(block(2^7);duration=1,step=0.25)

--- a/examples/TwoD_circle.jl
+++ b/examples/TwoD_circle.jl
@@ -11,6 +11,9 @@ function circle(n,m;Re=250)
     Simulation((n+2,m+2), [U,0.], R; ν, body)
 end
 
-circ = circle(3*2^6,2^7);
-sim_gif!(circ;duration=0.1)
-sim_gif!(circ;duration=10,step=0.25)
+function test(tend=10)
+    sim = circle(3*2^6,2^7)
+    sim_step!(sim,0.01)
+    @time sim_step!(sim,tend)
+end
+# sim_gif!(circle(3*2^6,2^7);duration=10,step=0.25)

--- a/examples/TwoD_circle.jl
+++ b/examples/TwoD_circle.jl
@@ -7,20 +7,10 @@ function circle(n,m;Re=250)
     U,R,center = 1., m/8., [m/2,m/2]
     ν=U*R/Re
     @show R,ν
-
-    a = Flow((n+2,m+2),[U,0.];ν=ν)
-    measure!(a,AutoBody(x->norm2(x .- center) - R))
-    Simulation(U,R,a,MultiLevelPoisson(a.μ₀))
+    body = AutoBody((x,t)->norm2(x .- center) - R)
+    Simulation((n+2,m+2), [U,0.], R; ν, body)
 end
 
-function sim_gif!(sim;duration=1,step=0.1,verbose=true)
-    t₀ = round(sim_time(sim))
-    t = range(t₀,t₀+duration;step)
-    gr(show=false)
-    @time @gif for tᵢ in t
-        sim_step!(sim,tᵢ;verbose)
-        @inside sim.flow.σ[I] = WaterLily.curl(3,I,sim.flow.u)*sim.L/sim.U
-        flood(sim.flow.σ,shift=(-0.5,-0.5),clims=(-5,5))
-    end
-    return
-end
+circ = circle(3*2^6,2^7);
+sim_gif!(circ;duration=0.1)
+sim_gif!(circ;duration=10,step=0.25)

--- a/examples/TwoD_circle.jl
+++ b/examples/TwoD_circle.jl
@@ -8,16 +8,9 @@ function circle(n,m;Re=250)
     ν=U*R/Re
     @show R,ν
 
-    # Immerse a circle (change for other shapes)
-    c = BDIM_coef(n+2,m+2,2) do xy
-        norm2(xy .- center) - R  # signed distance function
-    end
-
-    # Initialize Simulation object
-    u = zeros(n+2,m+2,2)
-    a = Flow(u,c,[U,0.],ν=ν)
-    b = MultiLevelPoisson(c)
-    Simulation(U,R,a,b)
+    a = Flow((n+2,m+2),[U,0.];ν=ν)
+    measure!(a,AutoBody(x->norm2(x .- center) - R))
+    Simulation(U,R,a,MultiLevelPoisson(a.μ₀))
 end
 
 function sim_gif!(sim;duration=1,step=0.1,verbose=true)

--- a/examples/TwoD_plots.jl
+++ b/examples/TwoD_plots.jl
@@ -27,3 +27,11 @@ function sim_gif!(sim;duration=1,step=0.1,verbose=true)
     end
     return
 end
+
+function vectors(f::Array)
+    x = axes(f,1)' .* ones(size(f,2))
+    y = ones(size(f,2))' .* axes(f,2)
+    u,v = f[:,:,1]',f[:,:,2]'
+    Plots.quiver(x[:],y[:],quiver=(u[:],v[:]),
+                aspect_ratio=:equal)
+end

--- a/examples/TwoD_plots.jl
+++ b/examples/TwoD_plots.jl
@@ -15,3 +15,15 @@ function flood(f::Array;shift=(0.,0.),cfill=:RdBu_11,clims=(),kv...)
 end
 
 addbody(x,y;c=:black) = Plots.plot!(Shape(x,y), c=c, legend=false)
+
+function sim_gif!(sim;duration=1,step=0.1,verbose=true)
+    t₀ = round(sim_time(sim))
+    t = range(t₀,t₀+duration;step)
+    gr(show=false)
+    @time @gif for tᵢ in t
+        sim_step!(sim,tᵢ;verbose)
+        @inside sim.flow.σ[I] = WaterLily.curl(3,I,sim.flow.u)*sim.L/sim.U
+        flood(sim.flow.σ,shift=(-0.5,-0.5),clims=(-5,5))
+    end
+    return
+end

--- a/src/AutoBody.jl
+++ b/src/AutoBody.jl
@@ -13,7 +13,7 @@ using ForwardDiff,DiffResults
     measure(body::AutoBody,x::Vector,t::Real)
 
 ForwardDiff is used to determine the geometry properties from the `sdf`.
-Note: U only contains the normal component which is generally not sufficient.
+Note: V only contains the normal component which is generally not sufficient.
 """
 function measure(body::AutoBody,x::Vector,t::Real)
     result = DiffResults.HessianResult(x)
@@ -21,8 +21,8 @@ function measure(body::AutoBody,x::Vector,t::Real)
     d = DiffResults.value(result)
     n̂ = DiffResults.gradient(result)
     κ = curvature(DiffResults.hessian(result))
-    U = -ForwardDiff.derivative(t->body.sdf(x,t), t) .* n̂
-    d,n̂,κ,U
+    V = -ForwardDiff.derivative(t->body.sdf(x,t), t) .* n̂
+    d,n̂,κ,V
 end
 
 using LinearAlgebra: tr

--- a/src/Body.jl
+++ b/src/Body.jl
@@ -10,7 +10,7 @@ to query the body geometry for these properties at location `x` and time `t`:
     `d :: Real`, Signed distance to surface
     `n̂ :: Vector`, Outward facing unit normal
     `κ :: Vector`, Mean and Gaussian curvature
-    `U :: Vector`, Body velocity
+    `V :: Vector`, Body velocity
 
 """
 abstract type AbstractBody end

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -55,9 +55,8 @@ struct Flow{N,M}
         f,p,σ = zeros(N),zeros(M),zeros(M)
         new{n,m}(u,u⁰,μ₀,V,f,p,σ,U,[Δt],[0],ν)
     end
-    function Flow(N::Tuple,U;Δt=0.25,ν=0.)
-        m = length(N)
-        Flow(zeros(N...,m),ones(N...,m),U;Δt=Δt,ν=ν)
+    function Flow(N::Tuple,U;Δt=0.25,ν=0.,uλ::Function=(i,x)->0.)
+        Flow(apply(uλ,N...,length(N)),ones(N...,length(N)),U;Δt,ν)
     end
 end
 

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -55,6 +55,10 @@ struct Flow{N,M}
         f,p,σ = zeros(N),zeros(M),zeros(M)
         new{n,m}(u,u⁰,μ₀,V,f,p,σ,U,[Δt],[0],ν)
     end
+    function Flow(N::Tuple,U;Δt=0.25,ν=0.)
+        m = length(N)
+        Flow(zeros(N...,m),ones(N...,m),U;Δt=Δt,ν=ν)
+    end
 end
 
 @fastmath function project!(a::Flow{n,m},b::AbstractPoisson{n,m}) where {n,m}

--- a/src/MultiLevelPoisson.jl
+++ b/src/MultiLevelPoisson.jl
@@ -29,7 +29,7 @@ struct MultiLevelPoisson{N,M} <: AbstractPoisson{N,M}
         end
         text = "MultiLevelPoisson requires size=a2ⁿ, where a<10, n>1"
         @assert length(levels)>1 & all(size(levels[end].x).<10) text
-        new{n,n-1}(levels)
+        new{n-1,n}(levels)
     end
 end
 
@@ -49,7 +49,7 @@ end
 
 mult(ml::MultiLevelPoisson,x) = mult(ml.levels[1],x)
 
-function solve!(x::Array{Float64,m},ml::MultiLevelPoisson{n,m},b::Array{Float64,m};log=false,tol=1e-3,itmx=32) where {n,m}
+function solve!(x::Array{Float64,n},ml::MultiLevelPoisson{n},b::Array{Float64,n};log=false,tol=1e-3,itmx=32) where n
     p = ml.levels[1]
     p.x .= x
     residual!(p,b); r₂ = L₂(p.r)

--- a/src/Poisson.jl
+++ b/src/Poisson.jl
@@ -10,28 +10,28 @@ The resulting linear system is
     Ax = [L+D+L']x = b
 
 where A is symmetric, block-tridiagonal and extremely sparse. Implemented on a
-structured grid of dimension M, then L has dimension N=M+1 and size(L,N)=M.
+structured grid of dimension N, then L has dimension M=N+1 and size(L,M)=N.
 Moreover, D[I]=-∑ᵢ(L[I,i]+L'[I,i]). This means matrix storage, multiplication,
 ect can be easily implemented and optimized without external libraries.
 
 To help iteratively solve the system above, the Poisson structure holds
-helper arrays for inv(D), the error ϵ=x̂=x, and residual r=b-Ax. An iterative
+helper arrays for inv(D), the error ϵ, and residual r=b-Ax. An iterative
 solution method then estimates the error ϵ=̃A⁻¹r and increments x+=ϵ, r-=Aϵ.
 """
 abstract type AbstractPoisson{N,M} end
 struct Poisson{N,M} <: AbstractPoisson{N,M}
-    L :: Array{Float64,N} # Lower diagonal coefficients
-    D :: Array{Float64,M} # Diagonal coefficients
-    iD :: Array{Float64,M} # 1/Diagonal
-    x :: Array{Float64,M} # approximate solution
-    ϵ :: Array{Float64,M} # increment/error
-    r :: Array{Float64,M} # residual
-    function Poisson(L::Array{Float64,n}) where n
-        N = size(L); M = N[1:end-1]; m = length(M)
-        @assert N[end] == m
-        x,ϵ,r,D,iD = zeros(M),zeros(M),zeros(M),zeros(M),zeros(M)
-        @inbounds for I ∈ inside(M)
-            D[I] = -sum(L[I,i]+L[I+δ(i,m),i] for i ∈ 1:m)
+    L :: Array{Float64,M} # Lower diagonal coefficients
+    D :: Array{Float64,N} # Diagonal coefficients
+    iD :: Array{Float64,N} # 1/Diagonal
+    x :: Array{Float64,N} # approximate solution
+    ϵ :: Array{Float64,N} # increment/error
+    r :: Array{Float64,N} # residual
+    function Poisson(L::Array{Float64,m}) where m
+        M = size(L); N = M[1:end-1]; n = m-1
+        @assert M[end] == n
+        x,ϵ,r,D,iD = zeros(N),zeros(N),zeros(N),zeros(N),zeros(N)
+        @inbounds for I ∈ inside(N)
+            D[I] = -sum(L[I,i]+L[I+δ(i,n),i] for i ∈ 1:n)
             iD[I] = abs2(D[I])<1e-8 ? 0. : inv(D[I])
         end
         new{n,m}(L,D,iD,x,ϵ,r)
@@ -43,7 +43,7 @@ end
 @fastmath @inline multU(I::CartesianIndex{d},L,x) where {d} =
     sum(@inbounds(x[I+δ(a,I)]*L[I+δ(a,I),a]) for a ∈ 1:d)
 @fastmath @inline mult(I,L,D,x) = @inbounds(x[I]*D[I])+multL(I,L,x)+multU(I,L,x)
-function mult(p::Poisson{n,m},x::Array{Float64,m}) where {n,m}
+function mult(p::Poisson{n},x::Array{Float64,n}) where n
     @assert size(p.x)==size(x)
     b = zeros(size(p.x))
     @inside b[I] = mult(I,p.L,p.D,x)
@@ -63,7 +63,7 @@ SOR!(p::Poisson;ω=1.5)
 Successive Over Relaxation preconditioner. The routine uses backsubstitution
 to compute ϵ=̃A⁻¹r, where ̃A=[D/ω+L], and then increments x,r.
 """
-@fastmath function SOR!(p::Poisson{n,m}; ω=1.5) where {n,m}
+@fastmath function SOR!(p::Poisson; ω=1.5)
     @inbounds for I ∈ inside(p.r) # order matters here
         σ = p.r[I]-multL(I,p.L,p.ϵ)
         p.ϵ[I] = ω*σ*p.iD[I]
@@ -75,7 +75,7 @@ GS!(p::Poisson;it=0)
 
 Gauss-Sidel smoother. When it=0, the function serves as a Jacobi preconditioner.
 """
-@fastmath function GS!(p::Poisson{n,m};it=0) where {n,m}
+@fastmath function GS!(p::Poisson;it=0)
     @inside p.ϵ[I] = p.r[I]*p.iD[I]
     for i ∈ 1:it; @inbounds for I ∈ inside(p.r, reverse = i%2==0) # order matters here
         σ = p.r[I]-multL(I,p.L,p.ϵ)-multU(I,p.L,p.ϵ)
@@ -84,7 +84,7 @@ Gauss-Sidel smoother. When it=0, the function serves as a Jacobi preconditioner.
     increment!(p)
 end
 
-function solve!(x::Array{Float64,m},p::Poisson{n,m},b::Array{Float64,m};log=false,tol=1e-4,itmx=1e3) where {n,m}
+function solve!(x::Array{Float64,n},p::Poisson{n},b::Array{Float64,n};log=false,tol=1e-4,itmx=1e3) where n
     p.x .= x
     residual!(p,b); r₂ = L₂(p.r)
     log && (res = [r₂])

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -33,7 +33,7 @@ Return the current dimensionless time of the simulation `tU/L`
 where `t=sum(Δt)`, and `U`,`L` are the simulation velocity and length
 scales.
 """
-sim_time(sim::Simulation) = sum(sim.flow.Δt)*sim.U/sim.L
+sim_time(sim::Simulation) = sum(sim.flow.Δt[1:end-1])*sim.U/sim.L
 """
     sim_step!(sim::Simulation,t_end;verbose=false)
 

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -9,14 +9,14 @@ export AbstractPoisson,Poisson,solve!,mult
 include("MultiLevelPoisson.jl")
 export MultiLevelPoisson,solve!,mult
 
+include("Flow.jl")
+export Flow,mom_step!
+
 include("Body.jl")
-export AbstractBody,BDIM_coef,apply
+export AbstractBody,BDIM_coef,apply,measure!
 
 include("AutoBody.jl")
 export AutoBody,measure
-
-include("Flow.jl")
-export Flow,mom_step!
 
 include("Metrics.jl")
 

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -27,7 +27,6 @@ struct Simulation
     flow :: Flow
     body :: AbstractBody
     pois :: AbstractPoisson
-    function Simulation(U,L,flow,pois) new(U,L,flow,NoBody(),pois) end
     function Simulation(N::Tuple,U::Vector,L::Number;
                         uλ::Function=(i,x)->U[i],Δt=0.25,ν=0.,
                         body::AbstractBody=NoBody())

--- a/src/util.jl
+++ b/src/util.jl
@@ -39,6 +39,28 @@ end
     end
 end
 
+"""
+    apply(f, N...)
+
+Apply a vector function f(i,x) to the faces of a uniform staggered grid.
+"""
+function apply(f,N...)
+    # TODO be more clever with the type
+    c = Array{Float64}(undef,N...)
+    apply!(f,c)
+    return c
+end
+function apply!(f,c)
+    N = size(c)
+    for b ∈ 1:N[end]
+        @simd for I ∈ CR(N[1:end-1])
+            x = collect(Float16, I.I) # location at cell center
+            x[b] -= 0.5               # location at face
+            @inbounds c[I,b] = f(b,x) # apply function to location
+        end
+    end
+end
+
 function BC!(a::Array{T,4},A,f=1) where T
     for k∈1:size(a,3), j∈1:size(a,2)
         a[1,j,k,1] = a[2,j,k,1] = a[size(a,1),j,k,1] = f*A[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,8 @@ using Test
                     0. 0. 7. 0.
                     0. 0. 8. 0.
                     0. 0. 8. 0.],dims=3)
+    u = apply((i,x)->x[i],4,4,2)
+    @test [u[i,j,1].-(i-0.5) for i in 1:4, j in 1:4]==zeros(4,4)
 end
 
 function Poisson_test_2D(f,n)
@@ -46,11 +48,9 @@ end
 end
 
 @testset "Body.jl" begin
-    u = apply((i,x)->x[i],4,4,2)
-    @test [u[i,j,1].-(i-0.5) for i in 1:4, j in 1:4]==zeros(4,4)
-    @test BDIM_coef(i->1,4,8,2)==ones(4,8,2)
-    @test BDIM_coef(i->0,4,8,2)==0.5ones(4,8,2)
-    @test BDIM_coef(i->-1,4,8,2)≈zeros(4,8,2) atol=2eps(1.)
+    @test WaterLily.μ₀(3;ϵ=6)==WaterLily.μ₀(0.5)
+    @test WaterLily.μ₀(0)==0.5
+    @test WaterLily.μ₁(0;ϵ=2)==2*(1/4-1/π^2)
 end
 
 @testset "AutoBody.jl" begin
@@ -62,12 +62,9 @@ end
 
 @testset "Flow.jl" begin
     # Impulsive flow in a box
-    u = zeros(6,10,2)
-    c = ones(6,10,2)
     U = [2/3,-1/3]
-    a = Flow(u,c,U)
-    b = MultiLevelPoisson(c)
-    mom_step!(a,b) # now they should match
+    a = Flow((6,10),U)
+    mom_step!(a,MultiLevelPoisson(a.μ₀))
     @test L₂(a.u[:,:,1].-U[1]) < 1e-6*4*8
     @test L₂(a.u[:,:,2].-U[2]) < 1e-6*4*8
 end


### PR DESCRIPTION
Implementation of second order BDIM required defining a `AbstractBody` type, and a better `Simulation` constructor, in addition to the changes to the flow solver. 