### PR TITLE
Fix running examples on julia >=1.6.1

### DIFF
--- a/examples/ThreeD_TaylorGreenVortex.jl
+++ b/examples/ThreeD_TaylorGreenVortex.jl
@@ -24,4 +24,4 @@ function ω_mag_data(sim)
     return @view sim.flow.σ[2:end-1,2:end-1,2:end-1]
 end
 
-sim,fig = volume_plot(TGV(),ω_mag_data,fname="TGV.mp4",duration=10)
+sim,fig = volume_video!(TGV(),ω_mag_data,name="TGV.mp4",duration=10)

--- a/examples/TwoD_Julia.jl
+++ b/examples/TwoD_Julia.jl
@@ -32,7 +32,7 @@ function TwoD_julia_video(;p=6,Re=250,stop=60.)
         flood(sim.flow.σ,shift=(-0.5,-0.5),clims=(-5,5),
             cfill=:Blues,legend=false,border=:none)
         for (center,color) ∈ zip(centers,colors)
-            addbody(real(z+center),imag(z+center),c=color)
+            addbody(real(z.+center),imag(z.+center),c=color)
         end
     end
     return sim


### PR DESCRIPTION
Thanks for sharing these examples !

A quick fix for the following error:
```julia
$ julia examples/TwoD_Julia.jl
ERROR: LoadError: MethodError: no method matching +(::Vector{ComplexF64}, ::ComplexF64)
For element-wise addition, use broadcasting with dot syntax: array .+ scalar
Closest candidates are:
  +(::Any, ::Any, ::Any, ::Any...) at operators.jl:560
  +(::Base.TwicePrecision, ::Number) at twiceprecision.jl:267
  +(::ChainRulesCore.Composite{P, T} where T, ::P) where P at [...]/ChainRulesCore/NR7YR/src/differential_arithmetic.jl:184
  ...

```