### PR TITLE
Fix: Update repo URL in docs to `https://github.com/weymouth/WaterLily.jl`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Documenter, WaterLily
 
 makedocs(
     modules = [WaterLily],
-    repo="https://github.com/gabrielweymouth/WaterLily.jl",
+    repo="https://github.com/weymouth/WaterLily.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", nothing) == "true",
         canonical="https:/weymouth.github.io/WaterLily.jl/",


### PR DESCRIPTION
Closes #20 

This PR updates the Documenter.jl script to point to the new URL for the repo.