### PR TITLE
Fix "link to source" buttons in docs by removing `repo` from makedocs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,6 @@ using Documenter, WaterLily
 
 makedocs(
     modules = [WaterLily],
-    repo="https://github.com/weymouth/WaterLily.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", nothing) == "true",
         canonical="https:/weymouth.github.io/WaterLily.jl/",


### PR DESCRIPTION
Goal: Fixes #22 