### PR TITLE
add function addBody

### DIFF
--- a/src/AutoBody.jl
+++ b/src/AutoBody.jl
@@ -11,8 +11,8 @@ is composed automatically if provided, ie `sdf(x,t) = sdf(map(x,t),t)`.
 struct AutoBody{F1<:Function,F2<:Function} <: AbstractBody
     sdf::F1
     map::F2
-    function AutoBody(sdf,map=(x,t)->x)
-        comp(x,t) = sdf(map(x,t),t)
+    function AutoBody(sdf, map=(x,t)->x; compose=true)
+        comp(x,t) = compose ? sdf(map(x,t),t) : sdf(x,t)
         new{typeof(comp),typeof(map)}(comp, map)
     end
 end

--- a/src/AutoBody.jl
+++ b/src/AutoBody.jl
@@ -1,12 +1,16 @@
 """
-    AutoBody(sdf,map=(x,t)->x) <: AbstractBody
+    AutoBody(sdf,map=(x,t)->x; compose=true) <: AbstractBody
 
     - sdf(x::AbstractVector,t::Real)::Real: signed distance function
     - map(x::AbstractVector,t::Real)::AbstractVector: coordinate mapping function
+    - compose::Bool: if true, automatically compose the `map`, ie `sdf(x,t) = sdf(map(x,t),t)`
+                        else, `sdf` and `map` remain independent
 
 Define a geometry by its `sdf` and optional coordinate `map`. All other
 properties are determined using Automatic Differentiation. Note: the `map`
-is composed automatically if provided, ie `sdf(x,t) = sdf(map(x,t),t)`.
+is composed automatically if compose is set to `true`, ie `sdf(x,t) = sdf(map(x,t),t)`. 
+Both parameters remain independent otherwise. It can be particularly heplful to set it as 
+false when adding mulitple bodies together to create a more complexe one.
 """
 struct AutoBody{F1<:Function,F2<:Function} <: AbstractBody
     sdf::F1

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -105,63 +105,28 @@ function measure!(sim::Simulation,t=time(sim))
     update!(sim.pois,sim.flow.μ₀)
 end
 
-function offset(Bodies, L)
-	"""Creates a different offset for each of the bodies so that when the general map is computed, there is no problem of
-	body spontaneous generation. This offset is then substracted when the individual map is applied where it needs to be thus
-	hiding its existence."""
-	
-    sdfList = [ (x,t) -> offsetSdf(x,t,i) for i in 1:length(Bodies)]
-    mapList = [ (x,t) -> offsetMap(x,t,i) for i in 1:length(Bodies)]
-
-	function offsetSdf(x,t,i)
-		xc = x + [0.,(-1)^i * 100*i * L]
-		return Bodies[i][1](xc,t)
-	end
-
-	function offsetMap(x,t,i)
-        xc = Bodies[i][2](x,t)
-        return xc - [0.,(-1)^i * 100*i * L]
-	end
-
-	return (sdfList, mapList)
+function addBodies(bodies...)
+    map(x,t) = argmin(body->body.sdf(x,t),bodies).map(x,t)
+    sdf(x,t) = minimum(body->body.sdf(x,t),bodies)
+    AutoBody(sdf,map,compose=false)
 end
 
-function addBody(Bodies, L=100)
-	"""addBody(Bodies::Array{SVector{Function, Function}}, L=100)
-    
-        Bodies: array of SVector(sdf, map) for each of the independent bodies to add to the window.
-        L: carateristic dimension of the largest body, to create a great enough offset to delete the generetion of undesired body.
-
-        
-    The default distance between two independent bodies is set to 100L. It impacts both their placement to not disturbe the other maps,
-	in the function 'offset', and the selection of the second closest body to a given point in the function 'min_excluding_i'.
-	The coefficients are computed to determine where each map should be used, therefore creating a global map that impacts the 
-	whole simulation window.
-
-	The output can directly be used as the body argument in the Simulation function provided by WaterLily."""
-
-	sdfList, mapList = offset(Bodies, L)
-
-	function min_excluding_i(sdfL, mapL, i, x, t)
-		min_val = 100L
-		for j in eachindex(sdfL)
-			if j != i 
-				val = sdfL[j](mapL[j](x,t),t)
-				if val <= min_val
-					min_val = val
-				end
-			end
-		end
-		return min_val
-	end
-
-	coef = [(x,t) -> μ₀(min_excluding_i(sdfList, mapList, i, x, t) - sdfList[i](mapList[i](x,t),t),1) for i in range(1, length(sdfList))]
-
-	sdf(x,t) = minimum([sdfX(x,t) for sdfX in sdfList])
-	map(x,t) = sum([mapList[i](x,t)*coef[i](x,t) for i in range(1, length(mapList))])
-
-	return AutoBody(sdf, map)
+function intersectBodies(bodies...)
+    map(x,t) = argmin(body->body.sdf(x,t),bodies).map(x,t)
+    sdf(x,t) = maximum(body->body.sdf(x,t),bodies)
+    AutoBody(sdf,map,compose=false)
 end
 
-export Simulation,sim_step!,sim_time,measure!,addBody
+function morphBodies(A::AutoBody, B::AutoBody, morph)
+    map(x,t) = argmin(body->body.sdf(x,t),[A,B]).map(x,t)
+    sdf(x,t) = morph(A.sdf(x,t),B.sdf(x,t),t)
+    AutoBody(sdf,map,compose=false)
+end
+
+Base.:+(x::AutoBody, y::AutoBody) = addBodies(x,y)
+Base.:∪(x::AutoBody, y::AutoBody) = addBodies(x,y)
+Base.:∩(x::AutoBody, y::AutoBody) = intersectBodies(x,y)
+Base.:-(x::AutoBody, y::AutoBody) = intersectBodies(x,AutoBody((d,t)->-y.sdf(d,t),y.map,compose=false))
+
+export Simulation,sim_step!,sim_time,measure!
 end # module

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -1,14 +1,5 @@
 module WaterLily
 
-_nthread = Threads.nthreads()
-if _nthread==1
-    @warn "WaterLily.jl is running on a single thread.\n
-Launch Julia with multiple threads to enable multithreaded capabilities:\n
-    \$julia -t auto $PROGRAM_FILE"
-else
-    print("WaterLily.jl is running on ", _nthread, " thread(s)\n")
-end
-
 include("util.jl")
 export L₂,BC!,@inside,inside,δ,apply!,loc
 
@@ -105,5 +96,66 @@ function measure!(sim::Simulation,t=time(sim))
     update!(sim.pois,sim.flow.μ₀)
 end
 
-export Simulation,sim_step!,sim_time,measure!
+@fastmath kern₀(d) = 0.5+0.5d+0.5sin(π*d)/π
+μ₀(d,ϵ) = kern₀(clamp(d/ϵ,-1,1))
+
+function offset(Bodies, L)
+	"""Creates a different offset for each of the bodies so that when the general map is computed, there is no problem of
+	body spontaneous generation. This offset is then substracted when the individual map is applied where it needs to be thus
+	hiding its existence."""
+	
+    sdfList = [ (x,t) -> offsetSdf(x,t,i) for i in 1:length(Bodies)]
+    mapList = [ (x,t) -> offsetMap(x,t,i) for i in 1:length(Bodies)]
+
+	function offsetSdf(x,t, i)
+		xc = x + [0.,(-1)^i * 100*i * L]
+		return Bodies[i][1](xc,t)
+	end
+
+	function offsetMap(x,t, i)
+		xc = x - [0.,(-1)^i * 100*i * L]
+		return Bodies[i][2](xc,t)
+	end
+
+	return (sdfList, mapList)
+end
+
+function addBody(Bodies::Array{SVector{Function, Function}}, L=100)
+	"""addBody(Bodies::Array{SVector{Function, Function}}, L=100)
+    
+        Bodies: array of SVector(sdf, map) for each of the independent bodies to add to the window.
+        L: carateristic dimension of the largest body, to create a great enough offset to delete the generetion of undesired body.
+
+        
+    The default distance between two independent bodies is set to 100L. It impacts both their placement to not disturbe the other maps,
+	in the function 'offset', and the selection of the second closest body to a given point in the function 'min_excluding_i'.
+	The coefficients are computed to determine where each map should be used, therefore creating a global map that impacts the 
+	whole simulation window.
+
+	The output can directly be used as the body argument in the Simulation function provided by WaterLily."""
+
+	sdfList, mapList = offset(Bodies, L)
+
+	function min_excluding_i(sdfL, mapL, i, x, t)
+		min_val = 100L
+		for j in eachindex(sdfL)
+			if j != i 
+				val = sdfL[j](mapL[j](x,t),t)
+				if val <= min_val
+					min_val = val
+				end
+			end
+		end
+		return min_val
+	end
+
+	coef = [(x,t) -> μ₀(min_excluding_i(sdfList, mapList, i, x, t) - sdfList[i](mapList[i](x,t),t),1) for i in range(1, length(sdfList))]
+
+	sdf(x,t) = minimum([sdfX(x,t) for sdfX in sdfList])
+	map(x,t) = sum([mapList[i](x,t)*coef[i](x,t) for i in range(1, length(mapList))])
+
+	return AutoBody(sdf, map)
+end
+
+export Simulation,sim_step!,sim_time,measure!, addBody
 end # module

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -126,7 +126,8 @@ end
 Base.:+(x::AutoBody, y::AutoBody) = addBodies(x,y)
 Base.:∪(x::AutoBody, y::AutoBody) = addBodies(x,y)
 Base.:∩(x::AutoBody, y::AutoBody) = intersectBodies(x,y)
-Base.:-(x::AutoBody, y::AutoBody) = intersectBodies(x,AutoBody((d,t)->-y.sdf(d,t),y.map,compose=false))
+Base.:-(x::AutoBody) = AutoBody((d,t)->-x.sdf(d,t),x.map,compose=false)
+Base.:-(x::AutoBody, y::AutoBody) = x ∩ -y
 
 export Simulation,sim_step!,sim_time,measure!
 end # module

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -1,5 +1,14 @@
 module WaterLily
 
+_nthread = Threads.nthreads()
+if _nthread==1
+    @warn "WaterLily.jl is running on a single thread.\n
+Launch Julia with multiple threads to enable multithreaded capabilities:\n
+    \$julia -t auto $PROGRAM_FILE"
+else
+    print("WaterLily.jl is running on ", _nthread, " thread(s)\n")
+end
+
 include("util.jl")
 export L₂,BC!,@inside,inside,δ,apply!,loc
 


### PR DESCRIPTION
This function takes as input a list of SVectors containing the sdf and the map for every body to add to the simulation. The output is an Autobody that can directly be used as input in the Simulation function.

Example of three bodies generated with only two function of generation (shows the sdf(x,t)):

![jl_XqPkNWTa1C](https://user-images.githubusercontent.com/118433296/216302951-5292abe9-a6bc-4fe1-a230-7f4e2b7e224d.gif)
