### PR TITLE
Flow.jl MWE

### DIFF
--- a/CUDAEnv/Flow.jl
+++ b/CUDAEnv/Flow.jl
@@ -22,22 +22,22 @@ end
 @inline δ(i,I::CartesianIndex{N}) where {N} = δ(i,N)
 adapt!(u) = backend == CPU() ? u : adapt(CuArray, u)
 
-struct Flow{N, M, P, T}
+struct Flow{D, V, S, F, B, T}
     # Fluid fields
-    u :: AbstractArray{T, M} # velocity vector
-    u⁰:: AbstractArray{T, M} # previous velocity
-    f :: AbstractArray{T, M} # force vector
-    p :: AbstractArray{T, N} # pressure scalar
-    σ :: AbstractArray{T, N} # divergence scalar
+    u :: V # velocity vector
+    u⁰:: V # previous velocity
+    f :: V # force vector
+    p :: S # pressure scalar
+    σ :: S # divergence scalar
     # BDIM fields
-    V :: AbstractArray{T, M} # body velocity vector
-    σᵥ:: AbstractArray{T, N} # body velocity divergence
-    μ₀:: AbstractArray{T, M} # zeroth-moment on faces
-    μ₁:: AbstractArray{T, P} # first-moment vector on faces
+    V :: V # body velocity vector
+    σᵥ:: S # body velocity divergence
+    μ₀:: V # zeroth-moment on faces
+    μ₁:: F # first-moment vector on faces
     # Non-fields
-    bc:: AbstractVector{Tuple{CartesianIndex{N}, CartesianIndex{N}, Int}}
-    U :: NTuple{N, T}  # domain boundary values
-    Δt:: AbstractVector{T}  # time step
+    bc:: B
+    U :: NTuple{D, T}  # domain boundary values
+    Δt:: Vector{T}  # time step
     ν :: T                  # kinematic viscosity
     function Flow(N::NTuple{D}, U; Δt=0.25, ν=0., uλ::Function=(i, x) -> 0., T=Float64) where D
         Ng = N .+ 2
@@ -66,7 +66,7 @@ struct Flow{N, M, P, T}
         BC!(μ₀, tuple(zeros(T, D)...), bc)
         μ₁ = zeros(T, Ng..., D, D) |> O(D, 2) |> adapt!
 
-        new{D,D+1,D+2,T}(u,u⁰,f,p,σ,V,σᵥ,μ₀,μ₁,bc,U,T[Δt]|>adapt!,ν)
+        new{D,typeof(u),typeof(p),typeof(μ₁),typeof(bc),T}(u,u⁰,f,p,σ,V,σᵥ,μ₀,μ₁,bc,U,T[Δt],ν)
     end
 end
 

--- a/CUDAEnv/Flow.jl
+++ b/CUDAEnv/Flow.jl
@@ -1,0 +1,103 @@
+using KernelAbstractions, Adapt, OffsetArrays, BenchmarkTools, OutMacro
+
+if Base.find_package("CUDA") !== nothing
+    using CUDA
+    using CUDA.CUDAKernels
+    const backend = CUDABackend()
+    CUDA.allowscalar(false)
+else
+    const backend = CPU()
+end
+
+@inline ∂(a,I::CartesianIndex{d},f::AbstractArray{T,d}) where {T,d} = @inbounds f[I]-f[I-δ(a,I)]
+@inline ∂(a,I::CartesianIndex{m},u::AbstractArray{T,n}) where {T,n,m} = @inbounds u[I+δ(a,I),a]-u[I,a]
+
+# Utils (to be moved to utils.jl)
+O(D=0, d=1) = OffsetArrays.Origin(D > 0 ? (zeros(Int, D)..., ones(Int, d)...) : 0)
+function slice(dims::NTuple{N}, i, j, low = 1, trim = 0) where N
+    CartesianIndices(ntuple(k-> k == j ? (i:i) : (low:dims[k] - trim), N))
+end
+@inline CI(a...) = CartesianIndex(a...)
+@inline δ(i,N::Int) = CI(ntuple(j -> j==i ? 1 : 0, N))
+@inline δ(i,I::CartesianIndex{N}) where {N} = δ(i,N)
+adapt!(u) = backend == CPU() ? u : adapt(CuArray, u)
+
+struct Flow{N, M, P, T}
+    # Fluid fields
+    u :: AbstractArray{T, M} # velocity vector
+    u⁰:: AbstractArray{T, M} # previous velocity
+    f :: AbstractArray{T, M} # force vector
+    p :: AbstractArray{T, N} # pressure scalar
+    σ :: AbstractArray{T, N} # divergence scalar
+    # BDIM fields
+    V :: AbstractArray{T, M} # body velocity vector
+    σᵥ:: AbstractArray{T, N} # body velocity divergence
+    μ₀:: AbstractArray{T, M} # zeroth-moment on faces
+    μ₁:: AbstractArray{T, P} # first-moment vector on faces
+    # Non-fields
+    bc:: AbstractVector{Tuple{CartesianIndex{N}, CartesianIndex{N}, Int}}
+    U :: NTuple{N, T}  # domain boundary values
+    Δt:: AbstractVector{T}  # time step
+    ν :: T                  # kinematic viscosity
+    function Flow(N::NTuple{D}, U; Δt=0.25, ν=0., uλ::Function=(i, x) -> 0., T=Float64) where D
+        Ng = N .+ 2
+        Nd = (Ng..., D)
+        @assert length(U) == D
+        u = Array{T}(undef, Nd...) |> O(D) |> adapt!
+        # apply!(uλ, u) # not working yet, TODO
+
+        bc_list = Tuple{CartesianIndex, CartesianIndex, Int}[]
+        for d ∈ 1:D
+            slice_ghost_start = slice(Ng, 0, d, 1, 2)
+            slice_donor_start = slice_ghost_start .+ δ(d, D)
+            slice_ghost_end = slice(Ng, Ng[d] - 1, d, 1, 2)
+            slice_donor_end = slice_ghost_end .- δ(d, D)
+            push!(bc_list, zip(slice_ghost_start, slice_donor_start, ntuple(x -> d, length(slice_ghost_start)))...,
+                zip(slice_ghost_end, slice_donor_end, ntuple(x -> d, length(slice_ghost_end)))...)
+        end
+        bc = Tuple.(bc_list) |> adapt!
+
+        BC!(u, U, bc)
+        u⁰ = copy(u)
+        f, p, σ = zeros(T, Nd) |> O(D) |> adapt!, zeros(T, Ng) |> O() |> adapt!, zeros(T, Ng) |> O() |> adapt!
+        V, σᵥ = zeros(T, Nd) |> O(D) |> adapt!, zeros(T, Ng) |> O() |> adapt!
+
+        μ₀ = ones(T, Nd) |> O(D) |> adapt!
+        BC!(μ₀, tuple(zeros(T, D)...), bc)
+        μ₁ = zeros(T, Ng..., D, D) |> O(D, 2) |> adapt!
+
+        new{D,D+1,D+2,T}(u,u⁰,f,p,σ,V,σᵥ,μ₀,μ₁,bc,U,T[Δt]|>adapt!,ν)
+    end
+end
+
+
+# Apply boundary conditions to the ghost cells (bc) of a _vector_ field
+function BC!(u, U, bc, f = 1.0)
+    _BC!(backend, 64)(u, U, bc, f, ndrange=size(bc))
+end
+@kernel function _BC!(u, @Const(U), @Const(bc), @Const(f))
+    i = @index(Global, Linear)
+    ghostI, donorI, di = bc[i][1], bc[i][2], bc[i][3]
+    # _, D = size_u(u)
+    for d ∈ 1:2
+        if d == di
+            u[ghostI, d] = f * U[d]
+        else
+            u[ghostI, d] = u[donorI, d]
+        end
+    end
+end
+# Apply boundary conditions to the ghost cells (bc) of a _scalar_ field
+function BC!(u, bc)
+    _BC!(backend, 64)(u, bc, ndrange=size(bc))
+end
+@kernel function _BC!(u, @Const(bc))
+    i = @index(Global, Linear)
+    ghostI, donorI = bc[i][1], bc[i][2]
+    u[ghostI] = u[donorI]
+end
+
+# main
+N = (3, 4)
+flow = Flow(N, (1.0, 0.0); T = Float64);
+return nothing

--- a/CUDAEnv/bcs.jl
+++ b/CUDAEnv/bcs.jl
@@ -17,7 +17,7 @@ size_u(u) = splitn(size(u))
 @inline δ(i, I::CartesianIndex{N}) where {N} = δ(i, N)
 @inline ∂(a, I::CartesianIndex{d}, f::AbstractArray{T,d}) where {T, d} = @inbounds f[I] - f[I - δ(a, I)]
 @inline ∂(a, I::CartesianIndex{m}, u::AbstractArray{T,n}) where {T, n, m} = @inbounds u[I + δ(a, I), a] - u[I, a]
-origin0(D=0) = OffsetArrays.Origin(D > 0 ? (zeros(Int, D)..., 1) : 0)
+O(D=0, d=1) = OffsetArrays.Origin(D > 0 ? (zeros(Int, D)..., ones(Int, d)...) : 0)
 function slice(dims::NTuple{N}, i, j, low = 1, trim = 0) where N
     CartesianIndices(ntuple(k-> k == j ? (i:i) : (low:dims[k] - trim), N))
 end
@@ -28,33 +28,31 @@ struct Flow{B <: Backend, V, P, UBC, BC}
     u :: V
     σ :: P
     U :: UBC
-    bcs :: BC
+    bc :: BC
 end
 
 function Flow(N::NTuple{D}, U; backend = CPU(), ftype = Float32) where D
-    u = rand(ftype, ((N .+ 2)..., D)) |> origin0(D)
-    σ = Array{ftype}(undef, N .+ 2) |> origin0()
-    bcs, Ng = [], size(σ)
+    u = rand(ftype, ((N .+ 2)..., D)) |> O(D)
+    σ = rand(ftype, N .+ 2) |> O()
+    bc, Ng = Tuple{CartesianIndex, CartesianIndex, Int}[], size(σ)
     for d ∈ 1:D
         slice_ghost_start = slice(Ng, 0, d, 1, 2)
         slice_donor_start = slice_ghost_start .+ δ(d, D)
         slice_ghost_end = slice(Ng, Ng[d] - 1, d, 1, 2)
         slice_donor_end = slice_ghost_end .- δ(d, D)
-        push!(bcs, zip(slice_ghost_start, slice_donor_start, ntuple(x -> d, length(slice_ghost_start)))...,
+        push!(bc, zip(slice_ghost_start, slice_donor_start, ntuple(x -> d, length(slice_ghost_start)))...,
             zip(slice_ghost_end, slice_donor_end, ntuple(x -> d, length(slice_ghost_end)))...)
     end
-    return Flow(backend, adapt(ArrayT, u), adapt(ArrayT, σ), U, adapt(ArrayT, Tuple.(bcs)))
+    return Flow(backend, adapt(ArrayT, u), adapt(ArrayT, σ), U, adapt(ArrayT, bc))
 end
 
-# wrapper for boundary conditions kernel
-function bcs!(flow, f = 1.0)
-    _bcs!(backend, 64)(flow.u, flow.U, f, flow.bcs, ndrange=size(flow.bcs))
+# Apply boundary conditions to the ghost cells (bc) of a _vector_ field
+function BC!(u, U, bc, f = 1.0)
+    _BC!(backend, 64)(u, U, bc, f, ndrange=size(bc))
 end
-
-# bounary conditions kernel
-@kernel function _bcs!(u, @Const(U), @Const(f), @Const(bcs))
+@kernel function _BC!(u, @Const(U), @Const(bc), @Const(f))
     i = @index(Global, Linear)
-    ghostI, donorI, di = bcs[i][1], bcs[i][2], bcs[i][3]
+    ghostI, donorI, di = bc[i][1], bc[i][2], bc[i][3]
     _, D = size_u(u)
     for d ∈ 1:D
         if d == di
@@ -64,10 +62,20 @@ end
         end
     end
 end
+# Apply boundary conditions to the ghost cells (bc) of a _scalar_ field
+function BC!(u, bc)
+    _BC!(backend, 64)(u, bc, ndrange=size(bc))
+end
+@kernel function _BC!(u, @Const(bc))
+    i = @index(Global, Linear)
+    ghostI, donorI = bc[i][1], bc[i][2]
+    u[ghostI] = u[donorI]
+end
 
 # main
 const FT = Float32
 N = (3, 4)
 
 flow = Flow(N, (1.0, 0.0, 0.0); backend = backend, ftype = FT)
-@btime bcs!($flow)
+@btime BC!($flow.u, $flow.U, $flow.bc)
+@btime BC!($flow.σ, $flow.bc)


### PR DESCRIPTION
Flow.jl self-contained example. Also included in utils.jl the necessary functions to get new `Flow` working (commented out for the moment). Small improvements on bcs.jl in this sense too.
In `Flow`, `apply!(uλ, u)` still needs to be adapted.