### PR TITLE
Started porting Flow.jl using KernelAbstractions.jl [WIP]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 Manifest.toml
 /docs/build/
 .vscode/
+CUDAEnv/test.jl

--- a/CUDAEnv/Flow.jl
+++ b/CUDAEnv/Flow.jl
@@ -30,7 +30,6 @@ struct Flow{D, V, S, F, B, T}
         apply!(uλ, u)
 
         bc = WaterLily.bc_indices(Ng) |> f
-
         BC!(u, U, bc)
         u⁰ = copy(u)
         fv, p, σ = zeros(T, Nd) |> f, zeros(T, Ng) |> f, zeros(T, Ng) |> f

--- a/CUDAEnv/Flow.jl
+++ b/CUDAEnv/Flow.jl
@@ -1,44 +1,20 @@
 using WaterLily
-using WaterLily: δ, slice, apply!, BC!
 using CUDA: cu
+using BenchmarkTools
 
-@inline ∂(a,I::CartesianIndex{d},f::AbstractArray{T,d}) where {T,d} = @inbounds f[I]-f[I-δ(a,I)]
-@inline ∂(a,I::CartesianIndex{m},u::AbstractArray{T,n}) where {T,n,m} = @inbounds u[I+δ(a,I),a]-u[I,a]
+U, N = (2/3, -1/3), (2^10, 2^10)
+flowCPU = Flow(N, U)
+flowGPU = Flow(N, U; f=cu)
 
-struct Flow{D, V, S, F, T}
-    # Fluid fields
-    u :: V # velocity vector
-    u⁰:: V # previous velocity
-    f :: V # force vector
-    p :: S # pressure scalar
-    σ :: S # divergence scalar
-    # BDIM fields
-    V :: V # body velocity vector
-    σᵥ:: S # body velocity divergence
-    μ₀:: V # zeroth-moment on faces
-    μ₁:: F # first-moment vector on faces
-    # Non-fields
-    U :: NTuple{D, T} # domain boundary values
-    Δt:: Vector{T} # time step (stored in CPU memory)
-    ν :: T # kinematic viscosity
-    function Flow(N::NTuple{D}, U::NTuple{D}; Δt=0.25, ν=0., uλ::Function=(i, x) -> 0., f=identity, T=Float64) where D
-        Ng = N .+ 2
-        Nd = (Ng..., D)
-        @assert length(U) == D
-        u = Array{T}(undef, Nd...) |> f
-        apply!(uλ, u)
-        BC!(u, U)
-        u⁰ = copy(u)
-        fv, p, σ = zeros(T, Nd) |> f, zeros(T, Ng) |> f, zeros(T, Ng) |> f
-        V, σᵥ = zeros(T, Nd) |> f, zeros(T, Ng) |> f
-        μ₀ = ones(T, Nd) |> f
-        BC!(μ₀, tuple(zeros(T, D)...))
-        μ₁ = zeros(T, Ng..., D, D) |> f
+@btime mom_step!($flowCPU, MultiLevelPoisson($flowCPU.p, $flowCPU.μ₀))
+@btime mom_step!($flowGPU, MultiLevelPoisson($flowGPU.p, $flowGPU.μ₀))
 
-        new{D,typeof(u),typeof(p),typeof(μ₁),T}(u,u⁰,fv,p,σ,V,σᵥ,μ₀,μ₁,U,T[Δt],ν)
-    end
-end
+# mom_step!(flowCPU, MultiLevelPoisson(flowCPU.p, flowCPU.μ₀))
+# mom_step!(flowGPU, MultiLevelPoisson(flowGPU.p, flowGPU.μ₀))
 
-# main
-N = (3, 4)
-flow = Flow(N, (1.0, 1.0); f = cu, T = Float64);
+# println(L₂(flowCPU.u[:,:,1].-U[1]) < 2e-5)
+# println(L₂(flowCPU.u[:,:,2].-U[2]) < 1e-5)
+# @allowscalar println(L₂(flowGPU.u[:,:,1].-U[1]) < 2e-5)
+# @allowscalar println(L₂(flowGPU.u[:,:,2].-U[2]) < 1e-5)
+
+return nothing;

--- a/CUDAEnv/Flow.jl
+++ b/CUDAEnv/Flow.jl
@@ -1,20 +1,37 @@
 using WaterLily
-using CUDA: cu
+using CUDA: cu, @allowscalar
 using BenchmarkTools
+
+@fastmath function mom_step_benchmark!(a::Flow,b::AbstractPoisson)
+    a.u⁰ .= a.u
+    a.u .= 0
+    # predictor u → u'
+    @btime conv_diff!($a.f,$a.u⁰,$a.σ,ν=$a.ν) # CPU: 10.308 ms (2730 allocations: 195.81 KiB). GPU: 177.927 μs (1287 allocations: 56.44 KiB)
+    @btime BDIM!($a) # CPU: 11.231 ms (541 allocations: 39.53 KiB). GPU: 50.584 μs (360 allocations: 26.66 KiB)
+    @btime BC!($a.u,$a.U) # CPU: 139.339 μs (1356 allocations: 97.41 KiB). GPU: 67.421 μs (611 allocations: 26.11 KiB)
+    @btime project!($a,$b) # CPU: 9.187 ms (550 allocations: 39.72 KiB). GPU: 435.650 ms (1285003 allocations: 56.93 MiB)
+    @btime BC!($a.u,$a.U) # CPU: 138.663 μs (1355 allocations: 97.38 KiB). GPU: 68.190 μs (611 allocations: 26.11 KiB)
+    # corrector u → u¹
+    @btime conv_diff!($a.f,$a.u,$a.σ,ν=$a.ν) # CPU: 11.308 ms (2728 allocations: 195.75 KiB). GPU: 181.429 μs (1287 allocations: 56.44 KiB)
+    @btime BDIM!($a) # CPU: 11.354 ms (542 allocations: 39.56 KiB). GPU: 57.634 μs (360 allocations: 26.66 KiB)
+    @btime BC!($a.u,$a.U,2) # CPU: 137.151 μs (1355 allocations: 97.38 KiB). GPU:  68.276 μs (611 allocations: 26.11 KiB)
+    @btime project!($a,$b,2) # CPU: 8.200 ms (550 allocations: 39.72 KiB). GPU: 424.575 ms (1285013 allocations: 56.93 MiB)
+    a.u ./= 2
+    @btime BC!($a.u,$a.U) # CPU: 137.820 μs (1356 allocations: 97.41 KiB). GPU: 68.100 μs (611 allocations: 26.11 KiB)
+    @btime push!($a.Δt,CFL($a)) # CPU: 4.298 ms (9 allocations: 528 bytes). GPU: N/A
+end
 
 U, N = (2/3, -1/3), (2^10, 2^10)
 flowCPU = Flow(N, U)
 flowGPU = Flow(N, U; f=cu)
 
-@btime mom_step!($flowCPU, MultiLevelPoisson($flowCPU.p, $flowCPU.μ₀))
-@btime mom_step!($flowGPU, MultiLevelPoisson($flowGPU.p, $flowGPU.μ₀))
+# mom_step_benchmark!(flowCPU, MultiLevelPoisson(flowCPU.p, flowCPU.μ₀))
+# mom_step_benchmark!(flowGPU, MultiLevelPoisson(flowGPU.p, flowGPU.μ₀))
 
-# mom_step!(flowCPU, MultiLevelPoisson(flowCPU.p, flowCPU.μ₀))
-# mom_step!(flowGPU, MultiLevelPoisson(flowGPU.p, flowGPU.μ₀))
+mom_step!(flowCPU, MultiLevelPoisson(flowCPU.p, flowCPU.μ₀))
+mom_step!(flowGPU, MultiLevelPoisson(flowGPU.p, flowGPU.μ₀))
 
-# println(L₂(flowCPU.u[:,:,1].-U[1]) < 2e-5)
-# println(L₂(flowCPU.u[:,:,2].-U[2]) < 1e-5)
-# @allowscalar println(L₂(flowGPU.u[:,:,1].-U[1]) < 2e-5)
-# @allowscalar println(L₂(flowGPU.u[:,:,2].-U[2]) < 1e-5)
-
-return nothing;
+println(L₂(flowCPU.u[:,:,1].-U[1]) < 2e-5) # true
+println(L₂(flowCPU.u[:,:,2].-U[2]) < 1e-5) # true
+@allowscalar println(L₂(flowGPU.u[:,:,1].-U[1]) < 2e-5) # false
+@allowscalar println(L₂(flowGPU.u[:,:,2].-U[2]) < 1e-5) # false

--- a/CUDAEnv/poisson.jl
+++ b/CUDAEnv/poisson.jl
@@ -19,17 +19,17 @@ b = mult(pois,soln);
 @btime WaterLily.increment!($pois)
 # 969.700 μs (0 allocations: 0 bytes) # 1.064 ms (634 allocations: 57.12 KiB) # 10.900 μs (207 allocations: 10.14 KiB)
 @btime WaterLily.Jacobi!($pois)
-# 8.033 ms (0 allocations: 0 bytes) # 11.259 ms (422 allocations: 38.19 KiB) SLOW
+# 8.033 ms (0 allocations: 0 bytes) # 11.259 ms (422 allocations: 38.19 KiB) # false
 typeof(pois.r.parent)<:Array && @btime WaterLily.SOR!($pois,it=1)
 
-ml,soln = Poisson_setup(MultiLevelPoisson,(2^10+2,2^10+2));
+ml,soln = Poisson_setup(MultiLevelPoisson,(2^10+2,2^10+2),f=cu);
 fine,coarse = ml.levels[1],ml.levels[2];
 WaterLily.residual!(fine,mult(fine,soln));
 # 637.800 μs (0 allocations: 0 bytes) # 135.500 μs (207 allocations: 17.83 KiB) # 2.737 μs (62 allocations: 2.78 KiB)
 @btime WaterLily.restrict!($coarse.r,$fine.r)
 # 446.200 μs (0 allocations: 0 bytes) # 198.100 μs (208 allocations: 17.84 KiB) # 2.850 μs (62 allocations: 2.78 KiB)
 @btime WaterLily.prolongate!($fine.ϵ,$coarse.x)
-# 11.833 ms (0 allocations: 0 bytes) # 14.754 ms (19673 allocations: 1.68 MiB) # 2.089 ms (41036 allocations: 1.97 MiB) MEMORY
+# 11.833 ms (0 allocations: 0 bytes) # 14.754 ms (19673 allocations: 1.68 MiB) # 2.089 ms (41036 allocations: 1.97 MiB) SLOW
 @btime WaterLily.Vcycle!($ml)
 # Vcycle! with (2^8+2)^3
 # 172.724 ms (0 allocations: 0 bytes) # 140.696 ms (17696 allocations: 1.65 MiB) # 1.924 ms (32015 allocations: 1.90 MiB)

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -4,7 +4,15 @@
 @fastmath quick(u,c,d) = median((5c+2d-u)/6,c,median(10c-9u,c,d))
 @fastmath vanLeer(u,c,d) = (c≤min(u,d) || c≥max(u,d)) ? c : c+(d-c)*(c-u)/(d-u)
 @inline ϕu(a,I,f,u,λ=quick) = @inbounds u>0 ? u*λ(f[I-2δ(a,I)],f[I-δ(a,I)],f[I]) : u*λ(f[I+δ(a,I)],f[I],f[I-δ(a,I)])
-@fastmath @inline div(I::CartesianIndex{m},u) where {m} = sum(@inbounds ∂(i,I,u) for i ∈ 1:m)
+# @fastmath @inline div(I::CartesianIndex{m},u) where {m} = sum(@inbounds ∂(i,I,u) for i ∈ 1:m)
+@fastmath @inline div(I::CartesianIndex{m},u) where {m} = mapreduce(identity, +, ∂(i,I,u) for i ∈ 1:m)
+@fastmath @inline function div_operator(I::CartesianIndex{m},u) where {m}
+    init=zero(eltype(u))
+    for i in 1:m
+     init += @inbounds ∂(i,I,u)
+    end
+    return init
+end
 function median(a,b,c)
     if a>b
         b>=c && return b
@@ -31,13 +39,19 @@ end
     r .= 0.
     N,n = size_u(u)
     for i ∈ 1:n, j ∈ 1:n
-        @loop r[I,i] += ϕ(j,CI(I,i),u)*ϕ(i,CI(I,j),u)-ν*∂(j,CI(I,i),u) over I ∈ slice(N,2,j,2)
+        @loop r[I,i] = r[I,i] + ϕ(j,CI(I,i),u)*ϕ(i,CI(I,j),u)-ν*∂(j,CI(I,i),u) over I ∈ slice(N,2,j,2)
         @loop Φ[I] = ϕu(j,CI(I,i),u,ϕ(i,CI(I,j),u))-ν*∂(j,CI(I,i),u) over I ∈ inside_u(N,j)
-        @loop r[I,i] += Φ[I] over I ∈ inside_u(N,j)
-        @loop r[I-δ(j,I),i] -= Φ[I] over I ∈ inside_u(N,j)
-        @loop r[I-δ(j,I),i] -= ϕ(j,CI(I,i),u)*ϕ(i,CI(I,j),u)-ν*∂(j,CI(I,i),u) over I ∈ slice(N,N[j],j,2)
+        @loop r[I,i] = r[I,i] + Φ[I] over I ∈ inside_u(N,j)
+        @loop r[I-δ(j,I),i] = r[I-δ(j,I),i] - Φ[I] over I ∈ inside_u(N,j)
+        @loop r[I-δ(j,I),i] = r[I-δ(j,I),i] - ϕ(j,CI(I,i),u)*ϕ(i,CI(I,j),u) + ν*∂(j,CI(I,i),u) over I ∈ slice(N,N[j],j,2)
     end
 end
+
+# @loop r[I,i] = r[I,i] + ϕ(j,CI(I,i),u)*ϕ(i,CI(I,j),u)-ν*∂(j,CI(I,i),u) over I ∈ slice(N,2,j,2)
+# @inside Φ[I] = ϕu(j,CI(I,i),u,ϕ(i,CI(I,j),u))-ν*∂(j,CI(I,i),u) # over I ∈ inside_u(N,j)
+# @inside r[I,i] = r[I,i] + Φ[I] # over I ∈ inside_u(N,j)
+# @inside r[I,i] = -r[I,i] + Φ[I+δ(j,I)] # over I ∈ inside_u(N,j)
+# @loop r[I,i] = -r[I,i] + ϕ(j,CI(I+δ(j,I),i),u)*ϕ(i,CI(I+δ(j,I),j),u)-ν*∂(j,CI(I+δ(j,I),i),u) over I ∈ slice(N,N[j],j,2)
 
 """
     Flow{D, V, S, F, B, T}
@@ -65,7 +79,7 @@ struct Flow{D, V, S, F, T}
     U :: NTuple{D, T} # domain boundary values
     Δt:: Vector{T} # time step (stored in CPU memory)
     ν :: T # kinematic viscosity
-    function Flow(N::NTuple{D}, U::NTuple{D}; Δt=0.25, ν=0., uλ::Function=(i, x) -> 0., f=identity, T=Float64) where D
+    function Flow(N::NTuple{D}, U::NTuple{D}; f=identity, Δt=0.25, ν=0., uλ::Function=(i, x) -> 0., T=Float64) where D
         Ng = N .+ 2
         Nd = (Ng..., D)
         @assert length(U) == D
@@ -86,17 +100,18 @@ end
 @fastmath function BDIM!(a::Flow{n}) where n
     @. a.f = a.u⁰+a.Δt[end]*a.f-a.V
     for j ∈ 1:n, i ∈ 1:n
-        @loop a.u[I,i] += μddn(j,CI(I,i),a.μ₁,a.f) over I ∈ inside(a.p)
+        @loop a.u[I,i] = a.u[I,i] + μddn(j,CI(I,i),a.μ₁,a.f) over I ∈ inside(a.p)
     end
     @. a.u += a.V+a.μ₀*a.f
 end
 @inline μddn(j,I::CartesianIndex,μ,f) = @inbounds 0.5μ[I,j]*(f[I+δ(j,I)]-f[I-δ(j,I)])
 
-@fastmath function project!(a::Flow{n},b::AbstractPoisson{n},w=1) where n
-    @inside a.σ[I] = (div(I,a.u)+w*a.σᵥ[I])/a.Δt[end]
-    solver!(a.p,b,a.σ)
+@fastmath function project!(a::Flow{n},b::AbstractPoisson,w=1) where n
+    dt = a.Δt[end]
+    @inside a.σ[I] = (div_operator(I,a.u)+w*a.σᵥ[I])/dt
+    solver!(b,a.σ)
     for i ∈ 1:n
-        @loop a.u[I,i] -= a.Δt[end]*a.μ₀[I,i]*∂(i,I,a.p) over I ∈ inside(a.σ)
+        @loop a.u[I,i] = a.u[I,i] - dt*a.μ₀[I,i]*∂(i,I,a.p) over I ∈ inside(a.σ)
     end
 end
 
@@ -116,7 +131,8 @@ and the `AbstractPoisson` pressure solver to project the velocity onto an incomp
     conv_diff!(a.f,a.u,a.σ,ν=a.ν)
     BDIM!(a); BC!(a.u,a.U,2)
     project!(a,b,2); a.u ./= 2; BC!(a.u,a.U)
-    _ENABLE_PUSH && push!(a.Δt,CFL(a))
+    # _ENABLE_PUSH && push!(a.Δt,CFL(a))
+    push!(a.Δt,CFL(a))
 end
 
 function CFL(a::Flow{n}) where n

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -70,18 +70,18 @@ struct Flow{D, V, S, F, B, T}
         Ng = N .+ 2
         Nd = (Ng..., D)
         @assert length(U) == D
-        u = Array{T}(undef, Nd...) |> OA(D) |> f
+        u = Array{T}(undef, Nd...) |> f
         apply!(uλ, u)
 
         bc = WaterLily.bc_indices(Ng) |> f
         BC!(u, U, bc)
         u⁰ = copy(u)
-        fv, p, σ = zeros(T, Nd) |> OA(D) |> f, zeros(T, Ng) |> OA() |> f, zeros(T, Ng) |> OA() |> f
-        V, σᵥ = zeros(T, Nd) |> OA(D) |> f, zeros(T, Ng) |> OA() |> f
+        fv, p, σ = zeros(T, Nd) |> f, zeros(T, Ng) |> f, zeros(T, Ng) |> f
+        V, σᵥ = zeros(T, Nd) |> f, zeros(T, Ng) |> f
 
-        μ₀ = ones(T, Nd) |> OA(D) |> f
+        μ₀ = ones(T, Nd) |> f
         BC!(μ₀, tuple(zeros(T, D)...), bc)
-        μ₁ = zeros(T, Ng..., D, D) |> OA(D, 2) |> f
+        μ₁ = zeros(T, Ng..., D, D) |> f
 
         new{D,typeof(u),typeof(p),typeof(μ₁),typeof(bc),T}(u,u⁰,fv,p,σ,V,σᵥ,μ₀,μ₁,bc,U,T[Δt],ν)
     end

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -10,7 +10,7 @@ include("MultiLevelPoisson.jl")
 export MultiLevelPoisson,solver!,mult
 
 include("Flow.jl")
-export Flow,mom_step!,conv_diff!,BDIM!,project!,BC!,CFL
+export Flow,mom_step!
 
 # include("Body.jl")
 # export AbstractBody

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -9,8 +9,8 @@ export AbstractPoisson,Poisson,solver!,mult
 include("MultiLevelPoisson.jl")
 export MultiLevelPoisson,solver!,mult
 
-# include("Flow.jl")
-# export Flow,mom_step!
+include("Flow.jl")
+export Flow,mom_step!
 
 # include("Body.jl")
 # export AbstractBody

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -10,7 +10,7 @@ include("MultiLevelPoisson.jl")
 export MultiLevelPoisson,solver!,mult
 
 include("Flow.jl")
-export Flow,mom_step!
+export Flow,mom_step!,conv_diff!,BDIM!,project!,BC!,CFL
 
 # include("Body.jl")
 # export AbstractBody

--- a/src/util.jl
+++ b/src/util.jl
@@ -21,9 +21,9 @@ Return CartesianIndices range excluding a single layer of cells on all boundarie
 # Return CartesianIndices range excluding the ghost-cells on the boundaries of
 # a _vector_ array on face `j` with size `dims`.
 # """
-# function inside_u(dims::NTuple{N},j) where {N}
-    # CartesianIndices(ntuple( i-> i==j ? (3:dims[i]-1) : (2:dims[i]), N))
-# end
+function inside_u(dims::NTuple{N},j) where {N}
+    CartesianIndices(ntuple( i-> i==j ? (3:dims[i]-1) : (2:dims[i]), N))
+end
 splitn(n) = Base.front(n),last(n)
 size_u(u) = splitn(size(u))
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -15,12 +15,12 @@ Return CartesianIndices range excluding a single layer of cells on all boundarie
 """
 @inline inside(a::AbstractArray) = CartesianIndices(map(ax->first(ax)+1:last(ax)-1,axes(a)))
 
-# """
-#     inside_u(dims,j)
+"""
+    inside_u(dims,j)
 
-# Return CartesianIndices range excluding the ghost-cells on the boundaries of
-# a _vector_ array on face `j` with size `dims`.
-# """
+Return CartesianIndices range excluding the ghost-cells on the boundaries of
+a _vector_ array on face `j` with size `dims`.
+"""
 function inside_u(dims::NTuple{N},j) where {N}
     CartesianIndices(ntuple( i-> i==j ? (3:dims[i]-1) : (2:dims[i]), N))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -93,25 +93,29 @@ end
     WaterLily.update!(pois)
     @test parent(pois.levels[3].D) == Float32[0 0 0 0; 0 -1 -1 0; 0 -1 -1 0; 0 0 0 0]
 
-    for f ∈ [identity,cu]    
+    for f ∈ [identity,cu]
         err,pois = Poisson_setup(MultiLevelPoisson,(2^6+2,2^6+2);f)
         @test err < 1e-5
         @test pois.n[] < 33 # [7,32]
 
         err,pois = Poisson_setup(MultiLevelPoisson,(2^4+2,2^4+2,2^4+2);f)
         @test err < 1e-5
-        @show pois.n[] < 12 # [6,11]
+        @test pois.n[] < 12 # [6,11]
     end
 end
 
-# @testset "Flow.jl" begin
-#     # Impulsive flow in a box
-#     U = [2/3,-1/3]
-#     a = Flow((14,10),U)
-#     mom_step!(a,MultiLevelPoisson(a.μ₀))
-#     @test L₂(a.u[:,:,1].-U[1]) < 2e-5
-#     @test L₂(a.u[:,:,2].-U[2]) < 1e-5
-# end
+@testset "Flow.jl" begin
+    # Impulsive flow in a box
+    U = (2/3, -1/3)
+    N = (2^6, 2^6)
+    for f ∈ [identity, cu]
+        a = Flow(N, U)
+        err,pois = Poisson_setup(MultiLevelPoisson, N .+ 2; f)
+        mom_step!(a, pois)
+        @test L₂(a.u[:,:,1].-U[1]) < 2e-5
+        @test L₂(a.u[:,:,2].-U[2]) < 1e-5
+    end
+end
 
 # @testset "Body.jl" begin
 #     @test WaterLily.μ₀(3,6)==WaterLily.μ₀(0.5,1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,18 +96,17 @@ end
     end
 end
 
-# @testset "Flow.jl" begin
-#     # Impulsive flow in a box
-#     U = (2/3, -1/3)
-#     N = (2^6, 2^6)
-#     for f ∈ [identity, cu]
-#         a = Flow(N, U)
-#         err,pois = Poisson_setup(MultiLevelPoisson, N .+ 2; f)
-#         mom_step!(a, pois)
-#         @test L₂(a.u[:,:,1].-U[1]) < 2e-5
-#         @test L₂(a.u[:,:,2].-U[2]) < 1e-5
-#     end
-# end
+@testset "Flow.jl" begin
+    # Impulsive flow in a box
+    U = (2/3, -1/3) 
+    N = (2^4, 2^4)
+    for f ∈ [identity, cu]
+        a = Flow(N, U; f, T=Float32)
+        mom_step!(a, MultiLevelPoisson(a.p,a.μ₀))
+        @test L₂(a.u[:,:,1].-U[1]) < 2e-5
+        @test L₂(a.u[:,:,2].-U[2]) < 1e-5
+    end
+end
 
 # @testset "Body.jl" begin
 #     @test WaterLily.μ₀(3,6)==WaterLily.μ₀(0.5,1)


### PR DESCRIPTION
Started porting Flow.jl using KernelAbstractions.jl.

Currently, `@loop` calls in `conv_diff!` need to be revised. Some calls such as `a[I] += ...` need to be expanded as `a[I] = a[I] + ...`. The `@loop ... inside_u(...)` calls need to be replaced by `@inside`. Even when applying these changes, errors still arise so I guess the new macros will need to be adapted for this.
