### PR TITLE
delta function for CI was not type-stable

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -10,8 +10,8 @@ GPUArray = Union{CuArray,ROCArray}
 
 Return a CartesianIndex of dimension `N` which is one at index `i` and zero elsewhere.
 """
-@inline δ(i,N::Int) = CI(ntuple(j -> j==i ? 1 : 0, N))
-@inline δ(i,I::CartesianIndex{N}) where {N} = δ(i,N)
+δ(i,::Val{N}) where N = CI(ntuple(j -> j==i ? 1 : 0, N))
+δ(i,I::CartesianIndex{N}) where N = δ(i, Val{N}())
 
 """
     inside(a)


### PR DESCRIPTION
I noticed that `@inline` had to be used in https://github.com/weymouth/WaterLily.jl/blob/28b5a383374486a4b68ad9cac9d81c379cab35c3/src/util.jl#L13
for the GPU code to compile, differently from CPU where this was not needed.
I rose this issue https://github.com/JuliaGPU/KernelAbstractions.jl/issues/392 and it was pointed out that `δ(d,I::CartesianIndex{N})` was type-unstable. This fix makes it type-stable.