### PR TITLE
Use Documenter v0.27

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,4 +2,4 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "~0.24"
+Documenter = "~0.27"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,8 +4,9 @@ makedocs(
     modules = [WaterLily],
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", nothing) == "true",
-        canonical="https:/weymouth.github.io/WaterLily.jl/",
+        canonical="https://weymouth.github.io/WaterLily.jl/",
         assets=String[],
+        mathengine = MathJax3()
     ),
     authors = "Gabriel Weymouth",
     sitename = "WaterLily.jl",

--- a/src/AutoBody.jl
+++ b/src/AutoBody.jl
@@ -6,9 +6,9 @@
   - `compose::Bool=true`: Flag for composing `sdf=sdf∘map`
 
 Implicitly define a geometry by its `sdf` and optional coordinate `map`. Note: the `map`
-is composed automatically if compose is set to `true`, ie `sdf(x,t) = sdf(map(x,t),t)`. 
-Both parameters remain independent otherwise. It can be particularly heplful to set it as 
-false when adding mulitple bodies together to create a more complexe one.
+is composed automatically if `compose=true`, i.e. `sdf(x,t) = sdf(map(x,t),t)`.
+Both parameters remain independent otherwise. It can be particularly heplful to set
+`compose=false` when adding mulitple bodies together to create a more complex one.
 """
 struct AutoBody{F1<:Function,F2<:Function} <: AbstractBody
     sdf::F1
@@ -44,7 +44,7 @@ using ForwardDiff
 
 Determine the implicit geometric properties from the `sdf` and `map`.
 The gradient of `d=sdf(map(x,t))` is used to improve `d` for pseudo-sdfs.
-The velocity is determined _soley_ from the optional `map` function.
+The velocity is determined _solely_ from the optional `map` function.
 """
 function measure(body::AutoBody,x,t)
     # eval d=f(x,t), and n̂ = ∇f
@@ -67,7 +67,7 @@ using LinearAlgebra: tr
     curvature(A::AbstractMatrix)
 
 Return `H,K` the mean and Gaussian curvature from `A=hessian(sdf)`.
-K=tr(minor(A)) in 3D and K=0 in 2D.
+`K=tr(minor(A))` in 3D and `K=0` in 2D.
 """
 function curvature(A::AbstractMatrix)
     H,K = 0.5*tr(A),0

--- a/src/Body.jl
+++ b/src/Body.jl
@@ -25,6 +25,7 @@ Queries the body geometry to fill the arrays:
 - `flow.σᵥ`, Body velocity divergence scaled by `μ₀-1`
 
 at time `t` using an immersion kernel of size `ϵ`.
+
 See Maertens & Weymouth, doi:[10.1016/j.cma.2014.09.007](https://doi.org/10.1016/j.cma.2014.09.007).
 """
 function measure!(a::Flow{N,T},body::AbstractBody;t=T(0),ϵ=1) where {N,T}

--- a/src/Body.jl
+++ b/src/Body.jl
@@ -15,7 +15,7 @@ and `n` & `V` are the normal and velocity vectors implied at `x`.
 """
 abstract type AbstractBody end
 """
-    `measure!(flow::Flow, body::AbstractBody; t=0, ϵ=1)`
+    measure!(flow::Flow, body::AbstractBody; t=0, ϵ=1)
 
 Queries the body geometry to fill the arrays:
 

--- a/src/Metrics.jl
+++ b/src/Metrics.jl
@@ -13,8 +13,8 @@ end
 """
     ke(I::CartesianIndex,u,U=0)
 
-Compute ½|u-U|² at center of cell `I` where `U` can be used
-to subtract a background flow.
+Compute ``½|𝐮-𝐔|²`` at center of cell `I` where `U` can be used
+to subtract a background flow (by default, `U=0`).
 """
 ke(I::CartesianIndex{m},u,U=fSV(zero,m)) where m = 0.125fsum(m) do i
     abs2(@inbounds(u[I,i]+u[I+δ(i,I),i]-2U[i]))
@@ -22,7 +22,7 @@ end
 """
     ∂(i,j,I,u)
 
-Compute ∂uᵢ/∂xⱼ at center of cell `I`. Cross terms are computed
+Compute ``∂uᵢ/∂xⱼ`` at center of cell `I`. Cross terms are computed
 less accurately than inline terms because of the staggered grid.
 """
 @fastmath @inline ∂(i,j,I,u) = (i==j ? ∂(i,I,u) :
@@ -46,7 +46,7 @@ end
 """
     curl(i,I,u)
 
-Compute component `i` of ∇×u at the __edge__ of cell `I`.
+Compute component `i` of ``𝛁×𝐮`` at the __edge__ of cell `I`.
 For example `curl(3,CartesianIndex(2,2,2),u)` will compute
 `ω₃(x=1.5,y=1.5,z=2)` as this edge produces the highest
 accuracy for this mix of cross derivatives on a staggered grid.
@@ -55,19 +55,19 @@ curl(i,I,u) = permute((j,k)->∂(j,CI(I,k),u), i)
 """
     ω(I::CartesianIndex{3},u)
 
-Compute 3-vector ω=∇×u at the center of cell `I`.
+Compute 3-vector ``𝛚=𝛁×𝐮`` at the center of cell `I`.
 """
 ω(I::CartesianIndex{3},u) = fSV(i->permute((j,k)->∂(k,j,I,u),i),3)
 """
     ω_mag(I::CartesianIndex{3},u)
 
-Compute |ω| at the center of cell `I`.
+Compute ``|𝛚|`` at the center of cell `I`.
 """
 ω_mag(I::CartesianIndex{3},u) = norm2(ω(I,u))
 """
     ω_θ(I::CartesianIndex{3},z,center,u)
 
-Compute ω⋅θ at the center of cell `I` where θ is the azimuth
+Compute ``𝛚⋅𝛉`` at the center of cell `I` where ``𝛉`` is the azimuth
 direction around vector `z` passing through `center`.
 """
 function ω_θ(I::CartesianIndex{3},z,center,u)

--- a/src/Metrics.jl
+++ b/src/Metrics.jl
@@ -13,7 +13,7 @@ end
 """
     ke(I::CartesianIndex,u,U=0)
 
-Compute ``½|𝐮-𝐔|²`` at center of cell `I` where `U` can be used
+Compute ``½∥𝐮-𝐔∥²`` at center of cell `I` where `U` can be used
 to subtract a background flow (by default, `U=0`).
 """
 ke(I::CartesianIndex{m},u,U=fSV(zero,m)) where m = 0.125fsum(m) do i
@@ -61,7 +61,7 @@ Compute 3-vector ``𝛚=𝛁×𝐮`` at the center of cell `I`.
 """
     ω_mag(I::CartesianIndex{3},u)
 
-Compute ``|𝛚|`` at the center of cell `I`.
+Compute ``∥𝛚∥`` at the center of cell `I`.
 """
 ω_mag(I::CartesianIndex{3},u) = norm2(ω(I,u))
 """

--- a/src/Poisson.jl
+++ b/src/Poisson.jl
@@ -98,7 +98,7 @@ using LinearAlgebra: ⋅
     pcg!(p::Poisson; it=6)
 
 Conjugate-Gradient smoother with Jacobi preditioning. Runs at most `it` iterations, 
-but will exit early if the Gram-Smit update parameter |α|<1% or |rD⁻¹r|<1e-8.
+but will exit early if the Gram-Schmidt update parameter `|α| < 1%` or `|r D⁻¹ r| < 1e-8`.
 Note: This runs for general backends and is the default smoother.
 """
 function pcg!(p::Poisson;it=6)

--- a/src/Poisson.jl
+++ b/src/Poisson.jl
@@ -14,8 +14,8 @@ where A is symmetric, block-tridiagonal and extremely sparse. Moreover,
 ect can be easily implemented and optimized without external libraries.
 
 To help iteratively solve the system above, the Poisson structure holds
-helper arrays for `inv(D)`, the error ϵ, and residual r=z-Ax. An iterative
-solution method then estimates the error ϵ=̃A⁻¹r and increments x+=ϵ, r-=Aϵ.
+helper arrays for `inv(D)`, the error `ϵ`, and residual `r=z-Ax`. An iterative
+solution method then estimates the error `ϵ=̃A⁻¹r` and increments `x+=ϵ`, `r-=Aϵ`.
 """
 abstract type AbstractPoisson{T,S,V} end
 struct Poisson{T,S<:AbstractArray{T},V<:AbstractArray{T}} <: AbstractPoisson{T,S,V}
@@ -135,7 +135,7 @@ Approximate iterative solver for the Poisson matrix equation `Ax=b`.
   - `A.n[end]`: stores the number of iterations performed.
   - `log`: If `true`, this function returns a vector holding the `L₂`-norm of the residual at each iteration.
   - `tol`: Convergence tolerance on the `L₂`-norm residual.
-  - 'itmx': Maximum number of iterations.
+  - `itmx`: Maximum number of iterations.
 """
 function solver!(p::Poisson;log=false,tol=1e-4,itmx=1e3)
     residual!(p); r₂ = L₂(p)

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -25,10 +25,10 @@ include("Metrics.jl")
 
 """
     Simulation(dims::NTuple, u_BC::NTuple, L::Number;
-               U=norm2(u_BC), Δt=0.25, ν=0., ϵ = 1,
+               U=norm2(u_BC), Δt=0.25, ν=0., ϵ=1,
                uλ::Function=(i,x)->u_BC[i],
                body::AbstractBody=NoBody(),
-               T=Float32, mem = Array)
+               T=Float32, mem=Array)
 
 Constructor for a WaterLily.jl simulation:
 
@@ -54,7 +54,7 @@ struct Simulation
     body :: AbstractBody
     pois :: AbstractPoisson
     function Simulation(dims::NTuple{N}, u_BC::NTuple{N}, L::Number;
-                        Δt=0.25, ν=0., U=√sum(abs2,u_BC), ϵ = 1,
+                        Δt=0.25, ν=0., U=√sum(abs2,u_BC), ϵ=1,
                         uλ::Function=(i,x)->u_BC[i],
                         body::AbstractBody=NoBody(),T=Float32,mem=Array) where N
         flow = Flow(dims,u_BC;uλ,Δt,ν,T,f=mem)

--- a/src/util.jl
+++ b/src/util.jl
@@ -44,7 +44,7 @@ L₂(a::GPUArray,R::CartesianIndices=inside(a)) = mapreduce(abs2,+,@inbounds(a[R
 """
     @inside <expr>
 
-Simple macro to automate efficient loops over cells excluding ghosts. For example
+Simple macro to automate efficient loops over cells excluding ghosts. For example,
 
     @inside p[I] = sum(loc(0,I))
 
@@ -55,7 +55,7 @@ becomes
 See [`@loop`](@ref).
 """
 macro inside(ex)
-    # Make sure its a single assignment
+    # Make sure it's a single assignment
     @assert ex.head == :(=) && ex.args[1].head == :(ref)
     a,I = ex.args[1].args[1:2]
     return quote # loop over the size of the reference
@@ -144,9 +144,10 @@ end
 
 """
     BC!(a,A,f=1)
+
 Apply boundary conditions to the ghost cells of a _vector_ field. A Dirichlet
 condition `a[I,i]=f*A[i]` is applied to the vector component _normal_ to the domain
-boundary. For example `aₓ(x)=f*Aₓ ∀ x ∈ minmax(X)`. A zero Nuemann condition
+boundary. For example `aₓ(x)=f*Aₓ ∀ x ∈ minmax(X)`. A zero Neumann condition
 is applied to the tangential components.
 """
 function BC!(a,A,f=1)

--- a/src/util.jl
+++ b/src/util.jl
@@ -166,7 +166,7 @@ end
 
 """
     BC!(a)
-Apply zero Nuemann boundary conditions to the ghost cells of a _scalar_ field.
+Apply zero Neumann boundary conditions to the ghost cells of a _scalar_ field.
 """
 function BC!(a)
     N = size(a)


### PR DESCRIPTION
This PR fixes some more typos and rendering issues in the docstrings.
Also, it uses Documenter v0.27 + MathJax3.

(Was there any particular reason Documenter was pinned to v0.24? If so, then I can revert that...)