### PR TITLE
add vtkWriter to WaterLily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.mp4
 *.dat
 *.pdf
+*.vti
+*.pvd
 Manifest.toml
 /docs/build/
 .vscode/

--- a/Project.toml
+++ b/Project.toml
@@ -10,10 +10,12 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [compat]
 AMDGPU = "^0.4.13,0.6"

--- a/examples/TwoD_circle_vtk.jl
+++ b/examples/TwoD_circle_vtk.jl
@@ -1,0 +1,49 @@
+using WaterLily
+
+# parameters
+L=2^4
+Re=250
+U =1
+
+# make a body
+radius, center = L/2, 3L
+Body = AutoBody((x,t)->√sum(abs2, [x[1],x[2],0.0] .- [center,center,0.0]) - radius)
+# 2D
+sim = Simulation((8L,6L),(U,0),L;U,ν=U*L/Re,body=Body,T=Float64)
+# 3D
+# sim = Simulation((8L,6L,16),(U,0,0),L;U,ν=U*L/Re,body=Body,T=Float64)
+
+# make a writer with some attributes
+velocity(a::Simulation) = a.flow.u
+pressure(a::Simulation) = a.flow.p
+body(a::Simulation) = a.flow.μ₀
+vorticity(a::Simulation) = (@inside a.flow.σ[I] = 
+                            WaterLily.curl(3,I,a.flow.u)*a.L/a.U;
+                            a.flow.σ)
+custom_attrib = Dict(
+    "Velocity" => velocity,
+    "Pressure" => pressure,
+    "Body" => body,
+    "Vorticity_Z" => vorticity,
+)# this maps what to write to the name in the file
+
+# make the writer
+wr = vtkWriter("TwoD_circle"; attrib=custom_attrib)
+
+# intialize
+t₀ = sim_time(sim)
+duration = 10
+tstep = 0.1
+
+# step and write
+@time for tᵢ in range(t₀,t₀+duration;step=tstep)
+    # update until time tᵢ in the background
+    sim_step!(sim,tᵢ,remeasure=false)
+
+    # write data
+    write!(wr, sim)
+
+    # print time step
+    println("tU/L=",round(tᵢ,digits=4),", Δt=",round(sim.flow.Δt[end],digits=3))
+end
+close(wr)

--- a/examples/TwoD_circle_vtk.jl
+++ b/examples/TwoD_circle_vtk.jl
@@ -23,7 +23,8 @@ sim = circle(mem=CUDA.CuArray);
 # make a writer with some attributes
 velocity(a::Simulation) = a.flow.u |> Array;
 pressure(a::Simulation) = a.flow.p |> Array;
-body(a::Simulation) = a.flow.μ₀ |> Array;
+body(a::Simulation) = (measure_sdf!(a.flow.σ, a.body); 
+                       a.flow.σ |> Array;)
 vorticity(a::Simulation) = (@inside a.flow.σ[I] = 
                             WaterLily.curl(3,I,a.flow.u)*a.L/a.U;
                             a.flow.σ |> Array;)

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -102,4 +102,8 @@ function measure!(sim::Simulation,t=time(sim))
 end
 
 export Simulation,sim_step!,sim_time,measure!
+
+include("vtkWriter.jl")
+export vtkWriter,write!,close
+
 end # module

--- a/src/vtkWriter.jl
+++ b/src/vtkWriter.jl
@@ -9,11 +9,13 @@ Custom attributes can be passed as `Dict{String,Function}` to the `attrib` keywo
 """
 struct vtkWriter
     fname::String
+    dir_name :: String
     collection::WriteVTK.CollectionFile
     output_attrib::Dict{String,Function}
     count::Vector{Int}
-    function vtkWriter(fname="WaterLily";attrib=default_attrib(),T=Float32)
-        new(fname,paraview_collection(fname),attrib,[0])
+    function vtkWriter(fname="WaterLily";attrib=default_attrib(),dir="vtk_data",T=Float32)
+        !isdir(dir) && mkdir(dir)
+        new(fname,dir,paraview_collection(fname),attrib,[0])
     end
 end
 """
@@ -34,7 +36,7 @@ to the collection file.
 """
 function write!(w::vtkWriter, sim::Simulation)
     k = w.count[1]; N=size(sim.flow.p)
-    vtk = vtk_grid(@sprintf("%s_%02i", w.fname, k), [1:n for n in N]...)
+    vtk = vtk_grid(w.dir_name*@sprintf("/%s_%02i", w.fname, k), [1:n for n in N]...)
     for (name,func) in w.output_attrib
         # this seems bad, but I @benchmark it and it's the same as just calling func()
         vtk[name] = size(func(sim))==N ? func(sim) : components_first(func(sim))

--- a/src/vtkWriter.jl
+++ b/src/vtkWriter.jl
@@ -1,0 +1,60 @@
+using WriteVTK
+using Printf: @sprintf
+"""
+    vtk_grid(name;attrib,T)
+
+Generates a `vtkWriter` that hold the collection name to which the `vtk` files are written.
+The default attributes that are saved are the `Velocity` and the `Pressure` fields.
+Custom attributes can be passed as `Dict{String,Function}` to the `attrib` keyword.    
+"""
+struct vtkWriter
+    fname::String
+    collection::WriteVTK.CollectionFile
+    output_attrib::Dict{String,Function}
+    count::Vector{Int}
+    function vtkWriter(fname="WaterLily";attrib=default_attrib(),T=Float32)
+        new(fname,paraview_collection(fname),attrib,[0])
+    end
+end
+"""
+    default_attrib()
+
+return a `Dict` containing the name and bound funtion for the default attributes. 
+The name is used as the key in the `vtk` file and the function generates the data
+to put in the file. With this approach, any variable can be save to the vtk file.
+"""
+_velocity(a::Simulation) = a.flow.u
+_pressure(a::Simulation) = a.flow.p
+default_attrib() = Dict("Velocity"=>_velocity, "Pressure"=>_pressure)
+"""
+    write!(w::vtkWriter, sim::Simulation)
+
+Write the simulation data at time `sim_time(sim)` to a `vti` file and add the file path
+to the collection file.
+"""
+function write!(w::vtkWriter, sim::Simulation)
+    k = w.count[1]; N=size(sim.flow.p)
+    vtk = vtk_grid(@sprintf("%s_%02i", w.fname, k), [1:n for n in N]...)
+    for (name,func) in w.output_attrib
+        # this seems bad, but I @benchmark it and it's the same as just calling func()
+        vtk[name] = size(func(sim))==N ? func(sim) : permutedims(func(sim))
+    end
+    vtk_save(vtk); w.count[1]=k+1
+    w.collection[round(sim_time(sim),digits=4)]=vtk
+end
+"""
+    close(w::vtkWriter)
+
+closes the `vtkWriter`, this is required to write the collection file.
+"""
+Base.close(w::vtkWriter)=(vtk_save(w.collection);nothing)
+"""
+    permutedims(a::Array)
+
+Permute the dimensions such that the i,j(,k) indices are the first dimensions and not the last
+this is reqired for the vtk file.
+"""
+function Base.permutedims(a::Array)
+    N=length(size(a)); p=[N,1:N-1...]
+    return permutedims(a,p)
+end

--- a/src/vtkWriter.jl
+++ b/src/vtkWriter.jl
@@ -37,7 +37,7 @@ function write!(w::vtkWriter, sim::Simulation)
     vtk = vtk_grid(@sprintf("%s_%02i", w.fname, k), [1:n for n in N]...)
     for (name,func) in w.output_attrib
         # this seems bad, but I @benchmark it and it's the same as just calling func()
-        vtk[name] = size(func(sim))==N ? func(sim) : permutedims(func(sim))
+        vtk[name] = size(func(sim))==N ? func(sim) : components_first(func(sim))
     end
     vtk_save(vtk); w.count[1]=k+1
     w.collection[round(sim_time(sim),digits=4)]=vtk
@@ -49,12 +49,12 @@ closes the `vtkWriter`, this is required to write the collection file.
 """
 Base.close(w::vtkWriter)=(vtk_save(w.collection);nothing)
 """
-    permutedims(a::Array)
+    components_first(a::Array)
 
-Permute the dimensions such that the i,j(,k) indices are the first dimensions and not the last
+Permute the dimensions such that the u₁,u₂,(u₃) components of a vector field are the first dimensions and not the last
 this is reqired for the vtk file.
 """
-function Base.permutedims(a::AbstractArray)
+function components_first(a::Array)
     N=length(size(a)); p=[N,1:N-1...]
     return permutedims(a,p)
 end

--- a/src/vtkWriter.jl
+++ b/src/vtkWriter.jl
@@ -23,8 +23,8 @@ return a `Dict` containing the name and bound funtion for the default attributes
 The name is used as the key in the `vtk` file and the function generates the data
 to put in the file. With this approach, any variable can be save to the vtk file.
 """
-_velocity(a::Simulation) = a.flow.u
-_pressure(a::Simulation) = a.flow.p
+_velocity(a::Simulation) = a.flow.u |> Array;
+_pressure(a::Simulation) = a.flow.p |> Array;
 default_attrib() = Dict("Velocity"=>_velocity, "Pressure"=>_pressure)
 """
     write!(w::vtkWriter, sim::Simulation)
@@ -54,7 +54,7 @@ Base.close(w::vtkWriter)=(vtk_save(w.collection);nothing)
 Permute the dimensions such that the i,j(,k) indices are the first dimensions and not the last
 this is reqired for the vtk file.
 """
-function Base.permutedims(a::Array)
+function Base.permutedims(a::AbstractArray)
     N=length(size(a)); p=[N,1:N-1...]
     return permutedims(a,p)
 end


### PR DESCRIPTION
Allows to export `WaterLily` simulations to `.vti` (image) grid.

The `vtkWriter` structure holds the `pvd` collection name, and some attributes `attrib::Dict{String, Function}` that maps a `vtk` variable to a function that extracts it from a `Simulation`. For example, to export the "Velocity" and "Pressure" fields the attributes will be
```julia
attrib = Dict("Velocity" => velocity(a::Simulation)=a.flow.u, 
              "Pressure" => pressure(a::Simulation)=a.flow.p)
``` 
This allows exporting arbitrary scalar, vector, and tensor fields to `vtk`. A more complex example would be to export the z-component of the vorticity with

```julia
attrib = Dict("Vorticity_Z" => vorticity_Z(a::Simulation)=
                                          (@inside a.flow.σ[I] = WaterLily.curl(3,I,a.flow.u)*a.L/a.U;
                                           a.flow.σ))
```

An example of this is provided in the file [TwoD_circle_vtk.jl](https://github.com/marinlauber/WaterLily/blob/vtkWriter/examples/TwoD_circle_vtk.jl).

I tested it on a GPU, and it works, it only requires piping the output of the writing functions to an `Array`, like
```julia
attrib = Dict("Velocity" => velocity(a::Simulation)=a.flow.u |> Array, 
              "Pressure" => pressure(a::Simulation)=a.flow.p |> Array,)
``` 
This is done by default for the `default_attrib()`, such that the writer is agnostic of the kernel.

By default, all data are treated as cell-centered data, but the writing functions can be easily modified to interpolate face values to the center.