### PR TITLE
Implement periodic boundary conditions

### DIFF
--- a/examples/TwoD_circle_periodicBC_convectiveBC.jl
+++ b/examples/TwoD_circle_periodicBC_convectiveBC.jl
@@ -1,0 +1,42 @@
+using WaterLily
+using StaticArrays
+using Plots
+include("TwoD_plots.jl")
+function circle(p=4;Re=250,mem=Array,U=1)
+    # Define simulation size, geometry dimensions, viscosity
+    L=2^p
+    center,r = SA[3L,3L], L
+    ν = U*L/Re
+
+    # functions for the body
+    norm2(x) = √sum(abs2,x)
+    function sdf(x,t)
+        norm2(SA[x[1]-center[1],mod(x[2]-6L,6L)-center[2]])-r
+    end
+    function map(x,t)
+        x.-SA[0.,U*t/2]
+    end
+    # make a body
+    body = AutoBody(sdf,map)
+
+    # return sim
+    Simulation((8L,6L),(U,0),L;ν,body,mem,perdir=(2,),exitBC=true)
+end
+
+sim = circle(5);
+
+# intialize
+t₀ = sim_time(sim)
+duration = 40.0
+tstep = 0.1
+
+# step and write
+@time @gif for tᵢ in range(t₀,t₀+duration;step=tstep)
+    # update until time tᵢ in the background
+    sim_step!(sim,tᵢ,remeasure=true)
+
+    # print time step
+    @inside sim.flow.σ[I] = WaterLily.curl(3,I,sim.flow.u)*sim.L/sim.U
+    flood(sim.flow.σ,clims=(-10,10),shift=(-0.5,-0.5)); body_plot!(sim)
+    println("tU/L=",round(tᵢ,digits=4),", Δt=",round(sim.flow.Δt[end],digits=3))
+end

--- a/src/Body.jl
+++ b/src/Body.jl
@@ -28,7 +28,7 @@ at time `t` using an immersion kernel of size `ϵ`.
 
 See Maertens & Weymouth, doi:[10.1016/j.cma.2014.09.007](https://doi.org/10.1016/j.cma.2014.09.007).
 """
-function measure!(a::Flow{N,T},body::AbstractBody;t=T(0),ϵ=1,perdir=(0,)) where {N,T}
+function measure!(a::Flow{N,T},body::AbstractBody;t=T(0),ϵ=1) where {N,T}
     a.V .= 0; a.μ₀ .= 1; a.μ₁ .= 0; a.σᵥ .= 0
     @fastmath @inline function fill!(μ₀,μ₁,V,σᵥ,d,I)
         d[I] = sdf(body,loc(0,I,T),t)
@@ -49,9 +49,8 @@ function measure!(a::Flow{N,T},body::AbstractBody;t=T(0),ϵ=1,perdir=(0,)) where
         end
     end
     @loop fill!(a.μ₀,a.μ₁,a.V,a.σᵥ,a.σ,I) over I ∈ inside(a.p)
-    BCVecPerNeu!(a.μ₀,Dirichlet=false, A=zeros(SVector{N,T}),perdir=perdir)  # add BC care for periodic & neu for μ₀
-    BCVecPerNeu!(a.V,perdir=perdir)  # add BC care for periodic & neu for body velocity, which is the most important step
-
+    BC!(a.μ₀,zeros(SVector{N,T}),a.exitBC,a.perdir;Dirichlet=false)  # add BC care for periodic & neu for μ₀
+    BC!(a.V ,zeros(SVector{N,T}),a.exitBC,a.perdir)  # add BC care for periodic & neu for body velocity, which is the most important step
     @inside a.σᵥ[I] = a.σᵥ[I]*div(I,a.V) # scaled divergence
     correct_div!(a.σᵥ)
 end

--- a/src/Body.jl
+++ b/src/Body.jl
@@ -28,7 +28,7 @@ at time `t` using an immersion kernel of size `ϵ`.
 
 See Maertens & Weymouth, doi:[10.1016/j.cma.2014.09.007](https://doi.org/10.1016/j.cma.2014.09.007).
 """
-function measure!(a::Flow{N,T},body::AbstractBody;t=T(0),ϵ=1) where {N,T}
+function measure!(a::Flow{N,T},body::AbstractBody;t=T(0),ϵ=1,perdir=(0,)) where {N,T}
     a.V .= 0; a.μ₀ .= 1; a.μ₁ .= 0; a.σᵥ .= 0
     @fastmath @inline function fill!(μ₀,μ₁,V,σᵥ,d,I)
         d[I] = sdf(body,loc(0,I,T),t)
@@ -49,9 +49,11 @@ function measure!(a::Flow{N,T},body::AbstractBody;t=T(0),ϵ=1) where {N,T}
         end
     end
     @loop fill!(a.μ₀,a.μ₁,a.V,a.σᵥ,a.σ,I) over I ∈ inside(a.p)
+    BCVecPerNeu!(a.μ₀,Dirichlet=false, A=zeros(SVector{N,T}),perdir=perdir)  # add BC care for periodic & neu for μ₀
+    BCVecPerNeu!(a.V,perdir=perdir)  # add BC care for periodic & neu for body velocity, which is the most important step
+
     @inside a.σᵥ[I] = a.σᵥ[I]*div(I,a.V) # scaled divergence
     correct_div!(a.σᵥ)
-    BC!(a.μ₀,zeros(SVector{N,T}))          # fill BCs
 end
 
 # Convolution kernel and its moments

--- a/src/Body.jl
+++ b/src/Body.jl
@@ -49,8 +49,8 @@ function measure!(a::Flow{N,T},body::AbstractBody;t=T(0),ϵ=1) where {N,T}
         end
     end
     @loop fill!(a.μ₀,a.μ₁,a.V,a.σᵥ,a.σ,I) over I ∈ inside(a.p)
-    BC!(a.μ₀,zeros(SVector{N,T}),a.exitBC,a.perdir;Dirichlet=false)  # add BC care for periodic & neu for μ₀
-    BC!(a.V ,zeros(SVector{N,T}),a.exitBC,a.perdir)  # add BC care for periodic & neu for body velocity, which is the most important step
+    BC!(a.μ₀,zeros(SVector{N,T}),a.exitBC,a.perdir) # BC on μ₀, don't fill normal component yet
+    BC!(a.V ,zeros(SVector{N,T}),a.exitBC,a.perdir)
     @inside a.σᵥ[I] = a.σᵥ[I]*div(I,a.V) # scaled divergence
     correct_div!(a.σᵥ)
 end

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -4,6 +4,7 @@
 @fastmath quick(u,c,d) = median((5c+2d-u)/6,c,median(10c-9u,c,d))
 @fastmath vanLeer(u,c,d) = (c≤min(u,d) || c≥max(u,d)) ? c : c+(d-c)*(c-u)/(d-u)
 @inline ϕu(a,I,f,u,λ=quick) = @inbounds u>0 ? u*λ(f[I-2δ(a,I)],f[I-δ(a,I)],f[I]) : u*λ(f[I+δ(a,I)],f[I],f[I-δ(a,I)])
+@inline ϕuSelf(I1,I2,I3,I4,f,u,λ=quick) = @inbounds u>0 ? u*λ(f[I1],f[I2],f[I3]) : u*λ(f[I4],f[I3],f[I2])
 @inline ϕuL(a,I,f,u,λ=quick) = @inbounds u>0 ? u*ϕ(a,I,f) : u*λ(f[I+δ(a,I)],f[I],f[I-δ(a,I)])
 @inline ϕuR(a,I,f,u,λ=quick) = @inbounds u<0 ? u*ϕ(a,I,f) : u*λ(f[I-2δ(a,I)],f[I-δ(a,I)],f[I])
 
@@ -32,17 +33,55 @@ function median(a,b,c)
     return a
 end
 
-function conv_diff!(r,u,Φ;ν=0.1)
+# function conv_diff!(r,u,Φ;ν=0.1)
+#     r .= 0.
+#     N,n = size_u(u)
+#     for i ∈ 1:n, j ∈ 1:n
+#         @loop r[I,i] += ϕuL(j,CI(I,i),u,ϕ(i,CI(I,j),u)) - ν*∂(j,CI(I,i),u) over I ∈ slice(N,2,j,2)
+#         @loop (Φ[I] = ϕu(j,CI(I,i),u,ϕ(i,CI(I,j),u)) - ν*∂(j,CI(I,i),u);
+#                r[I,i] += Φ[I]) over I ∈ inside_u(N,j)
+#         @loop r[I-δ(j,I),i] -= Φ[I] over I ∈ inside_u(N,j)
+#         @loop r[I-δ(j,I),i] += -ϕuR(j,CI(I,i),u,ϕ(i,CI(I,j),u)) + ν*∂(j,CI(I,i),u) over I ∈ slice(N,N[j],j,2)
+#     end
+# end
+function conv_diff!(r,u,Φ;ν=0.1,perdir=(0,))
     r .= 0.
     N,n = size_u(u)
     for i ∈ 1:n, j ∈ 1:n
-        @loop r[I,i] += ϕuL(j,CI(I,i),u,ϕ(i,CI(I,j),u)) - ν*∂(j,CI(I,i),u) over I ∈ slice(N,2,j,2)
+        # if it is periodic direction
+        tagper = (j in perdir)
+        # treatment for bottom boundary with BCs
+        !tagper && lowBoundary!(r,u,Φ,ν,i,j,N)
+        tagper && lowBoundaryPer!(r,u,Φ,ν,i,j,N)
+        # inner cells
         @loop (Φ[I] = ϕu(j,CI(I,i),u,ϕ(i,CI(I,j),u)) - ν*∂(j,CI(I,i),u);
                r[I,i] += Φ[I]) over I ∈ inside_u(N,j)
         @loop r[I-δ(j,I),i] -= Φ[I] over I ∈ inside_u(N,j)
-        @loop r[I-δ(j,I),i] += -ϕuR(j,CI(I,i),u,ϕ(i,CI(I,j),u)) + ν*∂(j,CI(I,i),u) over I ∈ slice(N,N[j],j,2)
+        # treatment for upper boundary with BCs
+        !tagper && upperBoundary!(r,u,Φ,ν,i,j,N)
+        tagper && upperBoundaryPer!(r,u,Φ,ν,i,j,N)
     end
+    # for i ∈ 1:n
+    #     @loop r[I,i] += g[i] over I ∈ inside_uWB(N,i)
+    # end
 end
+
+# Neumann BC Building block
+lowBoundary!(r,u,Φ,ν,i,j,N) = @loop r[I,i] += ϕuL(j,CI(I,i),u,ϕ(i,CI(I,j),u)) - ν*∂(j,CI(I,i),u) over I ∈ slice(N,2,j,2)
+upperBoundary!(r,u,Φ,ν,i,j,N) = @loop r[I-δ(j,I),i] += -ϕuR(j,CI(I,i),u,ϕ(i,CI(I,j),u)) + ν*∂(j,CI(I,i),u) over I ∈ slice(N,N[j],j,2)
+# innerCell!(r,u,Φ,ν,i,j,N) = (
+#     @loop (
+#         Φ[I] = ϕu(j,CI(I,i),u,ϕ(i,CI(I,j),u))-ν*∂(j,CI(I,i),u);
+#         r[I,i] += Φ[I]
+#     ) over I ∈ inside_u(N,j);
+#     @loop r[I-δ(j,I),i] -= Φ[I] over I ∈ inside_u(N,j)
+# )
+
+# Periodic BC Building block
+lowBoundaryPer!(r,u,Φ,ν,i,j,N) = @loop (
+    Φ[I] = ϕuSelf(CIj(j,CI(I,i),N[j]-2),CI(I,i)-δ(j,CI(I,i)),CI(I,i),CI(I,i)+δ(j,CI(I,i)), u, ϕ(i,CI(I,j), u))
+                  -ν*∂(j,CI(I,i),u); r[I,i] += Φ[I]) over I ∈ slice(N,2,j,2)
+upperBoundaryPer!(r,u,Φ,ν,i,j,N) = @loop r[I-δ(j,I),i] -= Φ[CIj(j,I,2)] over I ∈ slice(N,N[j],j,2)
 
 """
     Flow{D::Int, T::Float, Sf<:AbstractArray{T,D}, Vf<:AbstractArray{T,D+1}, Tf<:AbstractArray{T,D+2}}
@@ -71,17 +110,20 @@ struct Flow{D, T, Sf<:AbstractArray{T}, Vf<:AbstractArray{T}, Tf<:AbstractArray{
     Δt:: Vector{T} # time step (stored in CPU memory)
     ν :: T # kinematic viscosity
     exitBC :: Bool # Convection exit
-    function Flow(N::NTuple{D}, U::NTuple{D}; f=Array, Δt=0.25, ν=0., uλ::Function=(i, x) -> 0., T=Float64, exitBC = false) where D
+    perdir :: NTuple # direction of periodic direction
+    function Flow(N::NTuple{D}, U::NTuple{D}; f=Array, Δt=0.25, ν=0., uλ::Function=(i, x) -> 0., perdir=(0,), T=Float64, exitBC = false) where D
         Ng = N .+ 2
         Nd = (Ng..., D)
-        u = Array{T}(undef, Nd...) |> f; apply!(uλ, u); BC!(u, U, exitBC); exitBC!(u,u,U,0.)
+        u = Array{T}(undef, Nd...) |> f; apply!(uλ, u); 
+        # BC!(u, U, exitBC); exitBC!(u,u,U,0.)
+        BCVecPerNeu!(u;Dirichlet=true, A=U, perdir=perdir)
         u⁰ = copy(u)
         fv, p, σ = zeros(T, Nd) |> f, zeros(T, Ng) |> f, zeros(T, Ng) |> f
         V, σᵥ = zeros(T, Nd) |> f, zeros(T, Ng) |> f
         μ₀ = ones(T, Nd) |> f
-        BC!(μ₀,ntuple(zero, D))
+        # BC!(μ₀,ntuple(zero, D))
         μ₁ = zeros(T, Ng..., D, D) |> f
-        new{D,T,typeof(p),typeof(u),typeof(μ₁)}(u,u⁰,fv,p,σ,V,σᵥ,μ₀,μ₁,U,T[Δt],ν,exitBC)
+        new{D,T,typeof(p),typeof(u),typeof(μ₁)}(u,u⁰,fv,p,σ,V,σᵥ,μ₀,μ₁,U,T[Δt],ν,exitBC,perdir)
     end
 end
 
@@ -110,14 +152,17 @@ and the `AbstractPoisson` pressure solver to project the velocity onto an incomp
 @fastmath function mom_step!(a::Flow,b::AbstractPoisson)
     a.u⁰ .= a.u; scale_u!(a,0)
     # predictor u → u'
-    conv_diff!(a.f,a.u⁰,a.σ,ν=a.ν)
-    BDIM!(a); BC!(a.u,a.U,a.exitBC)
-    a.exitBC && exitBC!(a.u,a.u⁰,a.U,a.Δt[end]) # convective exit
-    project!(a,b); BC!(a.u,a.U,a.exitBC)
+    conv_diff!(a.f,a.u⁰,a.σ,ν=a.ν, perdir=a.perdir)
+    BDIM!(a); 
+    BCVecPerNeu!(a.u;Dirichlet=true, A=a.U, perdir=a.perdir)
+    project!(a,b); 
+    BCVecPerNeu!(a.u;Dirichlet=true, A=a.U, perdir=a.perdir)
     # corrector u → u¹
-    conv_diff!(a.f,a.u,a.σ,ν=a.ν)
-    BDIM!(a); scale_u!(a,0.5); BC!(a.u,a.U,a.exitBC)
-    project!(a,b,0.5); BC!(a.u,a.U,a.exitBC)
+    conv_diff!(a.f,a.u,a.σ,ν=a.ν, perdir=a.perdir)
+    BDIM!(a); scale_u!(a,0.5);
+    BCVecPerNeu!(a.u;Dirichlet=true, A=a.U, perdir=a.perdir)
+    project!(a,b,0.5); 
+    BCVecPerNeu!(a.u;Dirichlet=true, A=a.U, perdir=a.perdir)
     push!(a.Δt,CFL(a))
 end
 scale_u!(a,scale) = @loop a.u[Ii] *= scale over Ii ∈ inside_u(size(a.p))

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -92,8 +92,7 @@ struct Flow{D, T, Sf<:AbstractArray{T}, Vf<:AbstractArray{T}, Tf<:AbstractArray{
                   uλ::Function=(i, x) -> 0., perdir=(0,), exitBC=false, T=Float64) where D
         Ng = N .+ 2
         Nd = (Ng..., D)
-        u = Array{T}(undef, Nd...) |> f; apply!(uλ, u); 
-        # BC!(u, U, exitBC); exitBC!(u,u,U,0.)
+        u = Array{T}(undef, Nd...) |> f; apply!(uλ, u);
         BC!(u,U,exitBC,perdir); exitBC!(u,u,U,0.)
         u⁰ = copy(u)
         fv, p, σ = zeros(T, Nd) |> f, zeros(T, Ng) |> f, zeros(T, Ng) |> f

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -4,7 +4,7 @@
 @fastmath quick(u,c,d) = median((5c+2d-u)/6,c,median(10c-9u,c,d))
 @fastmath vanLeer(u,c,d) = (c≤min(u,d) || c≥max(u,d)) ? c : c+(d-c)*(c-u)/(d-u)
 @inline ϕu(a,I,f,u,λ=quick) = @inbounds u>0 ? u*λ(f[I-2δ(a,I)],f[I-δ(a,I)],f[I]) : u*λ(f[I+δ(a,I)],f[I],f[I-δ(a,I)])
-@inline ϕuSelf(I1,I2,I3,I4,f,u,λ=quick) = @inbounds u>0 ? u*λ(f[I1],f[I2],f[I3]) : u*λ(f[I4],f[I3],f[I2])
+@inline ϕuP(a,Ip,I,f,u,λ=quick) = @inbounds u>0 ? u*λ(f[Ip],f[I-δ(a,I)],f[I]) : u*λ(f[I+δ(a,I)],f[I],f[I-δ(a,I)])
 @inline ϕuL(a,I,f,u,λ=quick) = @inbounds u>0 ? u*ϕ(a,I,f) : u*λ(f[I+δ(a,I)],f[I],f[I-δ(a,I)])
 @inline ϕuR(a,I,f,u,λ=quick) = @inbounds u<0 ? u*ϕ(a,I,f) : u*λ(f[I-2δ(a,I)],f[I-δ(a,I)],f[I])
 
@@ -56,8 +56,7 @@ upperBoundary!(r,u,Φ,ν,i,j,N,::Val{false}) = @loop r[I-δ(j,I),i] += -ϕuR(j,C
 
 # Periodic BC Building block
 lowerBoundary!(r,u,Φ,ν,i,j,N,::Val{true}) = @loop (
-                Φ[I] = ϕuSelf(CIj(j,CI(I,i),N[j]-2),CI(I,i)-δ(j,CI(I,i)),CI(I,i),CI(I,i)+δ(j,CI(I,i)), u, ϕ(i,CI(I,j), u))
-                              -ν*∂(j,CI(I,i),u); r[I,i] += Φ[I]) over I ∈ slice(N,2,j,2)
+    Φ[I] = ϕuP(j,CIj(j,CI(I,i),N[j]-2),CI(I,i),u,ϕ(i,CI(I,j),u)) -ν*∂(j,CI(I,i),u); r[I,i] += Φ[I]) over I ∈ slice(N,2,j,2)
 upperBoundary!(r,u,Φ,ν,i,j,N,::Val{true}) = @loop r[I-δ(j,I),i] -= Φ[CIj(j,I,2)] over I ∈ slice(N,N[j],j,2)
 
 """

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -51,14 +51,14 @@ function conv_diff!(r,u,Φ;ν=0.1,perdir=(0,))
 end
 
 # Neumann BC Building block
-lowerBoundary!(r,u,Φ,ν,i,j,N,per::Val{false}) = @loop r[I,i] += ϕuL(j,CI(I,i),u,ϕ(i,CI(I,j),u)) - ν*∂(j,CI(I,i),u) over I ∈ slice(N,2,j,2)
-upperBoundary!(r,u,Φ,ν,i,j,N,per::Val{false}) = @loop r[I-δ(j,I),i] += -ϕuR(j,CI(I,i),u,ϕ(i,CI(I,j),u)) + ν*∂(j,CI(I,i),u) over I ∈ slice(N,N[j],j,2)
+lowerBoundary!(r,u,Φ,ν,i,j,N,::Val{false}) = @loop r[I,i] += ϕuL(j,CI(I,i),u,ϕ(i,CI(I,j),u)) - ν*∂(j,CI(I,i),u) over I ∈ slice(N,2,j,2)
+upperBoundary!(r,u,Φ,ν,i,j,N,::Val{false}) = @loop r[I-δ(j,I),i] += -ϕuR(j,CI(I,i),u,ϕ(i,CI(I,j),u)) + ν*∂(j,CI(I,i),u) over I ∈ slice(N,N[j],j,2)
 
 # Periodic BC Building block
-lowerBoundary!(r,u,Φ,ν,i,j,N,per::Val{true}) = @loop (
+lowerBoundary!(r,u,Φ,ν,i,j,N,::Val{true}) = @loop (
                 Φ[I] = ϕuSelf(CIj(j,CI(I,i),N[j]-2),CI(I,i)-δ(j,CI(I,i)),CI(I,i),CI(I,i)+δ(j,CI(I,i)), u, ϕ(i,CI(I,j), u))
                               -ν*∂(j,CI(I,i),u); r[I,i] += Φ[I]) over I ∈ slice(N,2,j,2)
-upperBoundary!(r,u,Φ,ν,i,j,N,per::Val{true}) = @loop r[I-δ(j,I),i] -= Φ[CIj(j,I,2)] over I ∈ slice(N,N[j],j,2)
+upperBoundary!(r,u,Φ,ν,i,j,N,::Val{true}) = @loop r[I-δ(j,I),i] -= Φ[CIj(j,I,2)] over I ∈ slice(N,N[j],j,2)
 
 """
     Flow{D::Int, T::Float, Sf<:AbstractArray{T,D}, Vf<:AbstractArray{T,D+1}, Tf<:AbstractArray{T,D+2}}
@@ -94,7 +94,7 @@ struct Flow{D, T, Sf<:AbstractArray{T}, Vf<:AbstractArray{T}, Tf<:AbstractArray{
         Nd = (Ng..., D)
         u = Array{T}(undef, Nd...) |> f; apply!(uλ, u); 
         # BC!(u, U, exitBC); exitBC!(u,u,U,0.)
-        BC!(u,U;saveexit=exitBC,Dirichlet=true,perdir=perdir); exitBC!(u,u,U,0.)
+        BC!(u,U,exitBC,perdir); exitBC!(u,u,U,0.)
         u⁰ = copy(u)
         fv, p, σ = zeros(T, Nd) |> f, zeros(T, Ng) |> f, zeros(T, Ng) |> f
         V, σᵥ = zeros(T, Nd) |> f, zeros(T, Ng) |> f
@@ -130,13 +130,13 @@ and the `AbstractPoisson` pressure solver to project the velocity onto an incomp
     a.u⁰ .= a.u; scale_u!(a,0)
     # predictor u → u'
     conv_diff!(a.f,a.u⁰,a.σ,ν=a.ν,perdir=a.perdir)
-    BDIM!(a); BC!(a.u,a.U;perdir=a.perdir)
+    BDIM!(a); BC!(a.u,a.U,a.exitBC,a.perdir)
     a.exitBC && exitBC!(a.u,a.u⁰,a.U,a.Δt[end]) # convective exit
-    project!(a,b); BC!(a.u,a.U;perdir=a.perdir)
+    project!(a,b); BC!(a.u,a.U,a.exitBC,a.perdir)
     # corrector u → u¹
     conv_diff!(a.f,a.u,a.σ,ν=a.ν,perdir=a.perdir)
-    BDIM!(a); scale_u!(a,0.5); BC!(a.u,a.U;perdir=a.perdir)
-    project!(a,b,0.5); BC!(a.u,a.U;perdir=a.perdir)
+    BDIM!(a); scale_u!(a,0.5); BC!(a.u,a.U,a.exitBC,a.perdir)
+    project!(a,b,0.5); BC!(a.u,a.U,a.exitBC,a.perdir)
     push!(a.Δt,CFL(a))
 end
 scale_u!(a,scale) = @loop a.u[Ii] *= scale over Ii ∈ inside_u(size(a.p))

--- a/src/MultiLevelPoisson.jl
+++ b/src/MultiLevelPoisson.jl
@@ -28,7 +28,7 @@ function restrictL!(a,b;perdir=(0,))
     for i ∈ 1:n
         @loop a[I,i] = restrictL(I,i,b) over I ∈ CartesianIndices(map(n->2:n-1,Na))
     end
-    BCVecPerNeu!(a,Dirichlet=false,perdir=perdir)  # correct μ₀ @ boundaries
+    BC!(a,zero(n);Dirichlet=false,perdir=perdir)  # correct μ₀ @ boundaries
 end
 restrict!(a,b) = @inside a[I] = restrict(I,b)
 prolongate!(a,b) = @inside a[I] = b[down(I)]
@@ -78,7 +78,7 @@ function Vcycle!(ml::MultiLevelPoisson;l=1)
     smooth!(coarse)
     # correct fine
     prolongate!(fine.ϵ,coarse.x)
-    BCPerNeu!(fine.ϵ, perdir=fine.perdir)
+    BC!(fine.ϵ;perdir=fine.perdir)
     increment!(fine)
 end
 
@@ -87,7 +87,7 @@ residual!(ml::MultiLevelPoisson,x) = residual!(ml.levels[1],x)
 
 function solver!(ml::MultiLevelPoisson;log=false,tol=1e-6,itmx=64)
     p = ml.levels[1]
-    BCPerNeu!(p.x,perdir=p.perdir)
+    BC!(p.x;perdir=p.perdir)
     residual!(p); r₂ = L₂(p)
     push!(ml.res0,r₂)
     log && (res = [r₂])
@@ -98,7 +98,7 @@ function solver!(ml::MultiLevelPoisson;log=false,tol=1e-6,itmx=64)
         log && push!(res,r₂)
         nᵖ+=1
     end
-    BCPerNeu!(p.x,perdir=p.perdir)
+    BC!(p.x;perdir=p.perdir)
     push!(ml.n,nᵖ); push!(ml.res,r₂)
     log && return res
 end

--- a/src/MultiLevelPoisson.jl
+++ b/src/MultiLevelPoisson.jl
@@ -23,12 +23,12 @@ function restrictML(b::Poisson)
     restrictL!(aL,b.L,perdir=b.perdir)
     Poisson(ax,aL,copy(ax);b.perdir)
 end
-function restrictL!(a,b;perdir=(0,))
+function restrictL!(a::AbstractArray{T},b;perdir=(0,)) where T
     Na,n = size_u(a)
     for i ∈ 1:n
         @loop a[I,i] = restrictL(I,i,b) over I ∈ CartesianIndices(map(n->2:n-1,Na))
     end
-    BC!(a,zero(n),false,perdir;Dirichlet=false)  # correct μ₀ @ boundaries
+    BC!(a,zeros(SVector{n,T}),false,perdir)  # correct μ₀ @ boundaries
 end
 restrict!(a,b) = @inside a[I] = restrict(I,b)
 prolongate!(a,b) = @inside a[I] = b[down(I)]
@@ -83,7 +83,7 @@ end
 mult!(ml::MultiLevelPoisson,x) = mult!(ml.levels[1],x)
 residual!(ml::MultiLevelPoisson,x) = residual!(ml.levels[1],x)
 
-function solver!(ml::MultiLevelPoisson;log=false,tol=1e-6,itmx=64)
+function solver!(ml::MultiLevelPoisson;log=false,tol=1e-3,itmx=32)
     p = ml.levels[1]
     BC!(p.x;perdir=p.perdir)
     residual!(p); r₂ = L₂(p)

--- a/src/MultiLevelPoisson.jl
+++ b/src/MultiLevelPoisson.jl
@@ -28,7 +28,7 @@ function restrictL!(a,b;perdir=(0,))
     for i ∈ 1:n
         @loop a[I,i] = restrictL(I,i,b) over I ∈ CartesianIndices(map(n->2:n-1,Na))
     end
-    BC!(a,zero(n);Dirichlet=false,perdir=perdir)  # correct μ₀ @ boundaries
+    BC!(a,zero(n),false,perdir;Dirichlet=false)  # correct μ₀ @ boundaries
 end
 restrict!(a,b) = @inside a[I] = restrict(I,b)
 prolongate!(a,b) = @inside a[I] = b[down(I)]

--- a/src/Poisson.jl
+++ b/src/Poisson.jl
@@ -83,7 +83,7 @@ Note: This runs for general backends, but is _very_ slow to converge.
 """
 @fastmath Jacobi!(p;it=1) = for _ ∈ 1:it
     @inside p.ϵ[I] = p.r[I]*p.iD[I]
-    BCPerNeu!(p.ϵ,perdir=p.perdir)
+    BC!(p.ϵ;perdir=p.perdir)
     increment!(p)
 end
 
@@ -102,7 +102,7 @@ function pcg!(p::Poisson;it=6)
     rho = r ⋅ z
     abs(rho)<1e-12 && return
     for i in 1:it
-        BCPerNeu!(ϵ,perdir=p.perdir)
+        BC!(ϵ;perdir=p.perdir)
         @inside z[I] = mult(I,p.L,p.D,ϵ)
         alpha = rho/(z[insideI]⋅ϵ[insideI])
         @loop (x[I] += alpha*ϵ[I];
@@ -135,7 +135,7 @@ Approximate iterative solver for the Poisson matrix equation `Ax=b`.
   - `itmx`: Maximum number of iterations.
 """
 function solver!(p::Poisson;log=false,tol=1e-4,itmx=1e3)
-    BCPerNeu!(p.x,perdir=p.perdir)
+    BC!(p.x;perdir=p.perdir)
     residual!(p); r₂ = L₂(p)
     log && (res = [r₂])
     nᵖ=0
@@ -144,7 +144,7 @@ function solver!(p::Poisson;log=false,tol=1e-4,itmx=1e3)
         log && push!(res,r₂)
         nᵖ+=1
     end
-    BCPerNeu!(p.x,perdir=p.perdir)
+    BC!(p.x;perdir=p.perdir)
     push!(p.n,nᵖ)
     log && return res
 end

--- a/src/Poisson.jl
+++ b/src/Poisson.jl
@@ -1,5 +1,5 @@
 """
-    Poisson
+    Poisson{N,M}
 
 Composite type for conservative variable coefficient Poisson equations:
 
@@ -27,12 +27,13 @@ struct Poisson{T,S<:AbstractArray{T},V<:AbstractArray{T}} <: AbstractPoisson{T,S
     r :: S # residual
     z :: S # source
     n :: Vector{Int16} # pressure solver iterations
-    function Poisson(x::AbstractArray{T},L::AbstractArray{T},z::AbstractArray{T}) where T
+    perdir :: NTuple # direction of periodic boundary condition
+    function Poisson(x::AbstractArray{T},L::AbstractArray{T},z::AbstractArray{T};perdir=(0,)) where T
         @assert axes(x) == axes(z) && axes(x) == Base.front(axes(L)) && last(axes(L)) == eachindex(axes(x))
         r = similar(x); fill!(r,0)
         ϵ,D,iD = copy(r),copy(r),copy(r)
         set_diag!(D,iD,L)
-        new{T,typeof(x),typeof(L)}(L,D,iD,x,ϵ,r,z,[])
+        new{T,typeof(x),typeof(L)}(L,D,iD,x,ϵ,r,z,[],perdir)
     end
 end
 
@@ -82,6 +83,7 @@ Note: This runs for general backends, but is _very_ slow to converge.
 """
 @fastmath Jacobi!(p;it=1) = for _ ∈ 1:it
     @inside p.ϵ[I] = p.r[I]*p.iD[I]
+    BCPerNeu!(p.ϵ,perdir=p.perdir)
     increment!(p)
 end
 
@@ -96,10 +98,13 @@ Note: This runs for general backends and is the default smoother.
 function pcg!(p::Poisson;it=6)
     x,r,ϵ,z = p.x,p.r,p.ϵ,p.z
     @inside z[I] = ϵ[I] = r[I]*p.iD[I]
+    insideI = inside(x) # [insideI]
     rho = r ⋅ z
+    abs(rho)<1e-12 && return
     for i in 1:it
+        BCPerNeu!(ϵ,perdir=p.perdir)
         @inside z[I] = mult(I,p.L,p.D,ϵ)
-        alpha = rho/(z⋅ϵ)
+        alpha = rho/(z[insideI]⋅ϵ[insideI])
         @loop (x[I] += alpha*ϵ[I];
                r[I] -= alpha*z[I]) over I ∈ inside(x)
         (i==it || abs(alpha)<1e-2) && return
@@ -112,6 +117,7 @@ function pcg!(p::Poisson;it=6)
     end
 end
 smooth!(p) = pcg!(p)
+# smooth!(p) = get_backend(p.r)==CPU() ? SOR!(p,it=3) : Jacobi!(p,it=20)
 
 L₂(p::Poisson) = p.r ⋅ p.r # special method since outside(p.r)≡0
 
@@ -129,6 +135,7 @@ Approximate iterative solver for the Poisson matrix equation `Ax=b`.
   - `itmx`: Maximum number of iterations.
 """
 function solver!(p::Poisson;log=false,tol=1e-4,itmx=1e3)
+    BCPerNeu!(p.x,perdir=p.perdir)
     residual!(p); r₂ = L₂(p)
     log && (res = [r₂])
     nᵖ=0
@@ -137,6 +144,7 @@ function solver!(p::Poisson;log=false,tol=1e-4,itmx=1e3)
         log && push!(res,r₂)
         nᵖ+=1
     end
+    BCPerNeu!(p.x,perdir=p.perdir)
     push!(p.n,nᵖ)
     log && return res
 end

--- a/src/Poisson.jl
+++ b/src/Poisson.jl
@@ -117,7 +117,6 @@ function pcg!(p::Poisson;it=6)
     end
 end
 smooth!(p) = pcg!(p)
-# smooth!(p) = get_backend(p.r)==CPU() ? SOR!(p,it=3) : Jacobi!(p,it=20)
 
 L₂(p::Poisson) = p.r ⋅ p.r # special method since outside(p.r)≡0
 

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -23,8 +23,6 @@ export AutoBody,measure,sdf,+,-
 
 include("Metrics.jl")
 
-abstract type AbstractSimulation end
-
 """
     Simulation(dims::NTuple, u_BC::NTuple, L::Number;
                U=norm2(u_BC), Δt=0.25, ν=0., ϵ=1,
@@ -48,7 +46,7 @@ Constructor for a WaterLily.jl simulation:
 
 See files in `examples` folder for examples.
 """
-struct Simulation <: AbstractSimulation
+struct Simulation
     U :: Number # velocity scale
     L :: Number # length scale
     ϵ :: Number # kernel width
@@ -65,7 +63,7 @@ struct Simulation <: AbstractSimulation
     end
 end
 
-time(sim::AbstractSimulation) = sum(sim.flow.Δt[1:end-1])
+time(sim::Simulation) = sum(sim.flow.Δt[1:end-1])
 """
     sim_time(sim::Simulation)
 
@@ -73,7 +71,7 @@ Return the current dimensionless time of the simulation `tU/L`
 where `t=sum(Δt)`, and `U`,`L` are the simulation velocity and length
 scales.
 """
-sim_time(sim::AbstractSimulation) = time(sim)*sim.U/sim.L
+sim_time(sim::Simulation) = time(sim)*sim.U/sim.L
 
 """
     sim_step!(sim::Simulation,t_end;remeasure=true,verbose=false)
@@ -98,7 +96,7 @@ end
 
 Measure a dynamic `body` to update the `flow` and `pois` coefficients.
 """
-function measure!(sim::AbstractSimulation,t=time(sim))
+function measure!(sim::Simulation,t=time(sim))
     measure!(sim.flow,sim.body;t,ϵ=sim.ϵ)
     update!(sim.pois)
 end

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -60,7 +60,7 @@ struct Simulation <: AbstractSimulation
                         uλ::Function=(i,x)->u_BC[i], exitBC=false,
                         body::AbstractBody=NoBody(),T=Float32,mem=Array) where N
         flow = Flow(dims,u_BC;uλ,Δt,ν,T,f=mem,perdir,exitBC)
-        measure!(flow,body;ϵ,perdir)
+        measure!(flow,body;ϵ)
         new(U,L,ϵ,flow,body,MultiLevelPoisson(flow.p,flow.μ₀,flow.σ;perdir))
     end
 end
@@ -99,7 +99,7 @@ end
 Measure a dynamic `body` to update the `flow` and `pois` coefficients.
 """
 function measure!(sim::AbstractSimulation,t=time(sim))
-    measure!(sim.flow,sim.body;t,ϵ=sim.ϵ,perdir=sim.flow.perdir)
+    measure!(sim.flow,sim.body;t,ϵ=sim.ϵ)
     update!(sim.pois)
 end
 

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -57,11 +57,11 @@ struct Simulation <: AbstractSimulation
     pois :: AbstractPoisson
     function Simulation(dims::NTuple{N}, u_BC::NTuple{N}, L::Number;
                         Δt=0.25, ν=0., U=√sum(abs2,u_BC), ϵ=1, perdir=(0,),
-                        uλ::Function=(i,x)->u_BC[i],
+                        uλ::Function=(i,x)->u_BC[i], exitBC=false,
                         body::AbstractBody=NoBody(),T=Float32,mem=Array) where N
-        flow = Flow(dims,u_BC;uλ,Δt,ν,T,f=mem,perdir=perdir)
-        measure!(flow,body;ϵ,perdir=perdir)
-        new(U,L,ϵ,flow,body,MultiLevelPoisson(flow.p,flow.μ₀,flow.σ;perdir=perdir))
+        flow = Flow(dims,u_BC;uλ,Δt,ν,T,f=mem,perdir,exitBC)
+        measure!(flow,body;ϵ,perdir)
+        new(U,L,ϵ,flow,body,MultiLevelPoisson(flow.p,flow.μ₀,flow.σ;perdir))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,11 +57,22 @@ arrays = setup_backends()
                 all(σ[2:end-1, 1] .== σ[2:end-1, 2]) && all(σ[2:end-1, end] .== σ[2:end-1, end-1])
 
         @allowscalar u[end,:,1] .= 3
-        BC!(u, U; saveexit=true) # save exit values
+        BC!(u,U,true) # save exit values
         @allowscalar @test all(u[end, :, 1] .== 3)
 
         WaterLily.exitBC!(u,u,U,0) # conservative exit check
         @allowscalar @test all(u[end,2:end-1, 1] .== U[1])
+
+        BC!(u,U,true,(2,)) # periodic in y and save exit values
+        @allowscalar @test all(u[:, 1:2, 1] .== u[:, end-1:end, 1]) && all(u[:, 1:2, 1] .== u[:,end-1:end,1])
+        BC!(σ;perdir=(1,2)) # periodic in two directions
+        @allowscalar @test all(σ[1, 2:end-1] .== σ[end-1, 2:end-1]) && all(σ[2:end-1, 1] .== σ[2:end-1, end-1])
+        
+        u = rand(Ng..., D) |> f # vector
+        BC!(u,U,true,(1,);Dirichlet=false) #saveexit has no effect here x-preiodic and zero-Neumann
+        @allowscalar @test all(u[:, 1, 1] .== u[:, 2, 1]) && all(u[:, end, 1] .== u[:, end-1, 1]) &&
+                           all(u[:, 1, 2] .== u[:, 2, 2]) && all(u[:, end, 2] .== u[:, end-1, 2]) &&
+                           all(u[1:2, :, 1] .== u[end-1:end, :, 1]) && all(u[1:2, :, 2] .== u[end-1:end, :, 2])
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,7 +34,8 @@ arrays = setup_backends()
 
     # for f ∈ arrays
     for f ∈ [Array]
-        p = Float64[i+j  for i ∈ 1:4, j ∈ 1:5] |> f
+        p = zeros(4,5) |> f
+        apply!(x->x[1]+x[2]+3,p) # add 2×1.5 to move edge to origin
         @test inside(p) == CartesianIndices((2:3,2:4))
         @test inside(p,buff=0) == CartesianIndices(p)
         @test L₂(p) == 187
@@ -56,7 +57,7 @@ arrays = setup_backends()
                 all(σ[2:end-1, 1] .== σ[2:end-1, 2]) && all(σ[2:end-1, end] .== σ[2:end-1, end-1])
 
         @allowscalar u[end,:,1] .= 3
-        BC!(u, U, true) # save exit values
+        BC!(u, U; saveexit=true) # save exit values
         @allowscalar @test all(u[end, :, 1] .== 3)
 
         WaterLily.exitBC!(u,u,U,0) # conservative exit check
@@ -98,20 +99,20 @@ end
     @test_throws AssertionError("MultiLevelPoisson requires size=a2ⁿ, where n>2") Poisson_setup(MultiLevelPoisson,(15+2,3^4+2))
 
     err,pois = Poisson_setup(MultiLevelPoisson,(10,10))
-    @test pois.levels[3].D == Float32[0 0 0 0; 0 -2 -2 0; 0 -2 -2 0; 0 0 0 0]
+    @test pois.levels[3].D == Float32[0 0 0 0; 0 -2 -3 0; 0 -3 -4 0; 0 0 0 0]
     @test err < 1e-5
 
     pois.levels[1].L[5:6,:,1].=0
     WaterLily.update!(pois)
-    @test pois.levels[3].D == Float32[0 0 0 0; 0 -1 -1 0; 0 -1 -1 0; 0 0 0 0]
+    @test pois.levels[3].D == Float32[0 0 0 0; 0 -1 -2 0; 0 -1 -2 0; 0 0 0 0]
 
     for f ∈ arrays
         err,pois = Poisson_setup(MultiLevelPoisson,(2^6+2,2^6+2);f)
         @test err < 1e-6
-        @test pois.n[] < 3
+        @test pois.n[] < 4
         err,pois = Poisson_setup(MultiLevelPoisson,(2^4+2,2^4+2,2^4+2);f)
         @test err < 1e-6
-        @test pois.n[] < 3
+        @test pois.n[] < 4
     end
 end
 


### PR DESCRIPTION
Implementation of periodic boundary conditions together with the convective exit.

There is an example [examples/TwoD_circle_periodicBC_convectiveBC.jl](file) that runs a y-periodic flow with a convective exit. The circle moves in the y-direction and crosses the boundary. This shows how to set up a periodic sdf.

I have added tests to check that the correct behavior is obtained for the boundary condition, for the different combinations of input.

I have not tested that the QUICK scheme implementation for periodic BC is correct, I just assumed it is based on @TzuYaoHuang simulations.

#### One caveat: there is no check that x-periodic flow and convective exit are not used at the same time, but because this will default to periodic, it should be fine.