### PR TITLE
Measure geometry between prediction and correction steps

### DIFF
--- a/examples/TwoD_cylinderVIV.jl
+++ b/examples/TwoD_cylinderVIV.jl
@@ -1,5 +1,4 @@
 using WaterLily
-using Plots; gr()
 using StaticArrays
 include("TwoD_plots.jl")
 
@@ -39,12 +38,8 @@ let
         # update until time tᵢ in the background
         t = sum(sim.flow.Δt[1:end-1])
         while t < tᵢ*sim.L/sim.U
-
-            # measure body
-            measure!(sim,t)
-
-            # update flow
-            mom_step!(sim.flow,sim.pois)
+            # predict flow
+            WaterLily.mom_predictor!(sim.flow,sim.pois)
             
             # pressure force
             force = -WaterLily.∮nds(sim.flow.p,sim.flow.f,sim.body,t)
@@ -58,6 +53,10 @@ let
 
             # update time, sets the pos/v0 correctly
             t0 = t; t += Δt
+
+            # measure body & correct flow
+            measure!(sim,t)
+            WaterLily.mom_corrector!(sim.flow,sim.pois)
         end
 
         # plot vorticity

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -180,7 +180,7 @@ end
     N = (2^4, 2^4)
     for f ∈ arrays
         a = Flow(N, U; f, T=Float32)
-        mom_step!(a, MultiLevelPoisson(a.p,a.μ₀,a.σ))
+        WaterLily.mom_predictor!(a, MultiLevelPoisson(a.p,a.μ₀,a.σ))
         @test L₂(a.u[:,:,1].-U[1]) < 2e-5
         @test L₂(a.u[:,:,2].-U[2]) < 1e-5
     end
@@ -285,9 +285,10 @@ import WaterLily: ×
 end
 
 @testset "WaterLily.jl" begin
-    radius = 8; ν=radius/250; T=Float32
+    radius = 8; ν=radius/250; T=Float32; nm = radius.*(4,4)
     circle(x,t) = √sum(abs2,x .- 2radius) - radius
     move(x,t) = x-SA[t,0]
+    accel(x,t) = x-SA[2t^2,0]
     plate(x,t) = √sum(abs2,x - SA[clamp(x[1],-radius+2,radius-2),0])-2
     function rotate(x,t)
         s,c = sincos(t/radius+1); R = SA[c s ; -s c]
@@ -298,24 +299,29 @@ end
         return SA[x+x^3*κ^2/6,y-x^2*κ/2]
     end
     # Test sim_time, and sim_step! stopping time
-    sim = Simulation(radius.*(4,4),(1,0),radius; body=AutoBody(circle), ν, T)
+    sim = Simulation(nm,(1,0),radius; body=AutoBody(circle), ν, T)
     @test sim_time(sim) == 0
     sim_step!(sim,0.1,remeasure=false)
     @test sim_time(sim) ≥ 0.1 > sum(sim.flow.Δt[1:end-2])*sim.U/sim.L
     for mem ∈ arrays, exitBC ∈ (true,false)
         # Test that remeasure works perfectly when V = U = 1
-        sim = Simulation(radius.*(4,4),(1,0),radius; body=AutoBody(circle,move), ν, T, mem, exitBC)
-        sim_step!(sim,0.01)
+        sim = Simulation(nm,(1,0),radius; body=AutoBody(circle,move), ν, T, mem, exitBC)
+        sim_step!(sim)
         @test all(sim.flow.u[:,radius,1].≈1)
         @test all(sim.pois.n .== 0)
+        # Test accelerating from U=0 to U=1
+        sim = Simulation(nm,(0,0),radius; U=1, body=AutoBody(circle,accel), ν, T, mem, exitBC)
+        sim_step!(sim)
+        @test sim.pois.n == [0,2]
+        @test maximum(sim.flow.u) > 0.5maximum(sim.flow.V) > 0
         # Test that non-uniform V doesn't break
-        sim = Simulation(radius.*(4,4),(0,0),radius; U=1, body=AutoBody(plate,rotate), ν, T, mem, exitBC)
-        sim_step!(sim,0.01)
+        sim = Simulation(nm,(0,0),radius; U=1, body=AutoBody(plate,rotate), ν, T, mem, exitBC)
+        sim_step!(sim)
         @test sim.pois.n == [2,1]
         @test 1 > sim.flow.Δt[end] > 0.5
         # Test that divergent V doesn't break
-        sim = Simulation(radius.*(4,4),(0,0),radius; U=1, body=AutoBody(plate,bend), ν, T, mem, exitBC)
-        sim_step!(sim,0.01)
+        sim = Simulation(nm,(0,0),radius; U=1, body=AutoBody(plate,bend), ν, T, mem, exitBC)
+        sim_step!(sim)
         @test sim.pois.n == [2,1]
         @test 1.2 > sim.flow.Δt[end] > 0.8
     end


### PR DESCRIPTION
The body should technically be measured between the prediction and correction steps in the time integration scheme since the velocity field is then "synced" with the body at the end of the time step. This PR makes that change, enabled by the improvement that was merged in PR #91. 
- `mom_step!` has been deleted and replaced with `mom_predictor!` and `mom_corrector!` which are not exported since they shouldn't be run by most users. 
- `sim_step!` has been changed to use call these functions with `measure(sim,t=timeNext(sim.flow)` in between. `sim_step!` was also refactored a bit to clean it up and calling without `t_end` will now run a single time step. 
- A new accelerating body test was added to ensure the flow is "synced" with the body at the start and end of `sim_step!`. 
- Finally, the TwoD_cylinderVIV example was also adjusted to update the geometry between prediction and correction.