### PR TITLE
measure body at timeNext instead of time

### DIFF
--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -75,29 +75,30 @@ scales.
 sim_time(sim::Simulation) = time(sim)*sim.U/sim.L
 
 """
-    sim_step!(sim::Simulation,t_end;max_steps=typemax(Int),remeasure=true,verbose=false)
+    sim_step!(sim::Simulation,t_end=sim(time)+Δt;max_steps=typemax(Int),remeasure=true,verbose=false)
 
 Integrate the simulation `sim` up to dimensionless time `t_end`.
 If `remeasure=true`, the body is remeasured at every time step.
 Can be set to `false` for static geometries to speed up simulation.
 """
-function sim_step!(sim::Simulation,t_end;max_steps=typemax(Int),verbose=false,remeasure=true)
-    t = time(sim)
-    while t < t_end*sim.L/sim.U && length(sim.flow.Δt) <= max_steps
-        remeasure && measure!(sim,t)
-        mom_step!(sim.flow,sim.pois) # evolve Flow
-        t += sim.flow.Δt[end]
-        verbose && println("tU/L=",round(t*sim.U/sim.L,digits=4),
+function sim_step!(sim::Simulation,t_end;remeasure=true,max_steps=typemax(Int),verbose=false)
+    while sim_time(sim) < t_end && length(sim.flow.Δt) <= max_steps
+        sim_step!(sim; remeasure)
+        verbose && println("tU/L=",round(sim_time(sim),digits=4),
             ", Δt=",round(sim.flow.Δt[end],digits=3))
     end
 end
+function sim_step!(sim::Simulation;remeasure=true)
+    remeasure && measure!(sim)
+    mom_step!(sim.flow,sim.pois)
+end
 
 """
-    measure!(sim::Simulation,t=time(sim))
+    measure!(sim::Simulation,t=timeNext(sim))
 
 Measure a dynamic `body` to update the `flow` and `pois` coefficients.
 """
-function measure!(sim::Simulation,t=time(sim))
+function measure!(sim::Simulation,t=timeNext(sim.flow))
     measure!(sim.flow,sim.body;t,ϵ=sim.ϵ)
     update!(sim.pois)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -285,9 +285,10 @@ import WaterLily: ×
 end
 
 @testset "WaterLily.jl" begin
-    radius = 8; ν=radius/250; T=Float32
+    radius = 8; ν=radius/250; T=Float32; nm = radius.*(4,4)
     circle(x,t) = √sum(abs2,x .- 2radius) - radius
     move(x,t) = x-SA[t,0]
+    accel(x,t) = x-SA[2t^2,0]
     plate(x,t) = √sum(abs2,x - SA[clamp(x[1],-radius+2,radius-2),0])-2
     function rotate(x,t)
         s,c = sincos(t/radius+1); R = SA[c s ; -s c]
@@ -298,24 +299,29 @@ end
         return SA[x+x^3*κ^2/6,y-x^2*κ/2]
     end
     # Test sim_time, and sim_step! stopping time
-    sim = Simulation(radius.*(4,4),(1,0),radius; body=AutoBody(circle), ν, T)
+    sim = Simulation(nm,(1,0),radius; body=AutoBody(circle), ν, T)
     @test sim_time(sim) == 0
     sim_step!(sim,0.1,remeasure=false)
     @test sim_time(sim) ≥ 0.1 > sum(sim.flow.Δt[1:end-2])*sim.U/sim.L
     for mem ∈ arrays, exitBC ∈ (true,false)
         # Test that remeasure works perfectly when V = U = 1
-        sim = Simulation(radius.*(4,4),(1,0),radius; body=AutoBody(circle,move), ν, T, mem, exitBC)
-        sim_step!(sim,0.01)
+        sim = Simulation(nm,(1,0),radius; body=AutoBody(circle,move), ν, T, mem, exitBC)
+        sim_step!(sim)
         @test all(sim.flow.u[:,radius,1].≈1)
         @test all(sim.pois.n .== 0)
+        # Test accelerating from U=0 to U=1
+        sim = Simulation(nm,(0,0),radius; U=1, body=AutoBody(circle,accel), ν, T, mem, exitBC)
+        sim_step!(sim)
+        @test sim.pois.n == [2,1]
+        @test maximum(sim.flow.u) > maximum(sim.flow.V) > 0
         # Test that non-uniform V doesn't break
-        sim = Simulation(radius.*(4,4),(0,0),radius; U=1, body=AutoBody(plate,rotate), ν, T, mem, exitBC)
-        sim_step!(sim,0.01)
+        sim = Simulation(nm,(0,0),radius; U=1, body=AutoBody(plate,rotate), ν, T, mem, exitBC)
+        sim_step!(sim)
         @test sim.pois.n == [2,1]
         @test 1 > sim.flow.Δt[end] > 0.5
         # Test that divergent V doesn't break
-        sim = Simulation(radius.*(4,4),(0,0),radius; U=1, body=AutoBody(plate,bend), ν, T, mem, exitBC)
-        sim_step!(sim,0.01)
+        sim = Simulation(nm,(0,0),radius; U=1, body=AutoBody(plate,bend), ν, T, mem, exitBC)
+        sim_step!(sim)
         @test sim.pois.n == [2,1]
         @test 1.2 > sim.flow.Δt[end] > 0.8
     end


### PR DESCRIPTION
Change `sim_step!` to measure the body at `timeNext` instead of `time`. This means the flow and BC are both at `timeNext` at the end of the time step. The results are exactly the same, just one time step earlier. 

While cleaning up `sim_step!`, I also made it so calling the function without `t_end` does a single step, and added an accelerating body test case to check that the flow is synced to the body velocity.