### PR TITLE
Make it possible to run the benchmarks outside of their directory

### DIFF
--- a/benchmark/benchmark.jl
+++ b/benchmark/benchmark.jl
@@ -55,7 +55,7 @@ function benchmark()
         sim_step!(getf(case)(p[1], backend; T=ft), typemax(ft); max_steps=1, verbose=false, remeasure=false) # warm up
         add_to_suite!(suite, getf(case); p=p, s=s, ft=ft, backend=backend) # create benchmark
         results[backend_str[backend]] = run(suite[backend_str[backend]], samples=1, evals=1, seconds=1e6, verbose=true) # run!
-        fname = joinpath(@__DIR__, "$(case)_$(p...)_$(s)_$(ft)_$(backend_str[backend])_$(git_hash)_$VERSION.json")
+        fname = "$(case)_$(p...)_$(s)_$(ft)_$(backend_str[backend])_$(git_hash)_$VERSION.json"
         BenchmarkTools.save(fname, results)
     end
 end

--- a/benchmark/benchmark.sh
+++ b/benchmark/benchmark.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 THIS_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-WATERLILY_ROOT=$(dirname "${THIS_DIR}")
+export WATERLILY_ROOT=$(dirname "${THIS_DIR}")
 
 # Utils
 join_array_comma () {
@@ -26,15 +26,14 @@ julia_version () {
     echo "${julia_v[2]}"
 }
 
-# Update project environment with new Julia version
+# Update project environment with new Julia version: Mark WaterLily as a development packag, then update dependencies and precompile.
 update_environment () {
     echo "Updating environment to Julia $version"
-    # Mark WaterLily as a development package. Then update dependencies and precompile.
-    julia +${version} --project="${WATERLILY_ROOT}" -e "using Pkg; Pkg.instantiate();"
+    julia +${version} --project=$THIS_DIR -e "using Pkg; Pkg.develop(PackageSpec(path=get(ENV, \"WATERLILY_ROOT\", \"\"))); Pkg.update();"
 }
 
 run_benchmark () {
-    full_args=(+${version} --project="${WATERLILY_ROOT}" --startup-file=no $args)
+    full_args=(+${version} --project=${THIS_DIR} --startup-file=no $args)
     echo "Running: julia ${full_args[@]}"
     julia "${full_args[@]}"
 }

--- a/benchmark/util.jl
+++ b/benchmark/util.jl
@@ -33,5 +33,6 @@ function add_to_suite!(suite, sim_function; p=(3,4,5), s=100, ft=Float32, backen
     end
 end
 
-git_hash = read(`git rev-parse --short HEAD`, String) |> x -> strip(x, '\n')
+waterlily_dir = get(ENV, "WATERLILY_ROOT", "")
+git_hash = read(`git -C $waterlily_dir rev-parse --short HEAD`, String) |> x -> strip(x, '\n')
 getf(str) = eval(Symbol(str))


### PR DESCRIPTION
The script currently assumes the benchmarks are run in the `benchmark/` directory, but I don't see why it has to be the case.