### PR TITLE
Small fixes in benchmark and sim_step!

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -38,6 +38,6 @@ julia --project compare.jl benchmark_1.json benchmark_2.json benchmark_3.json ..
 ```
 Note that each case benchmarks should be compared separately. If a single case is benchmarked, and all the JSON files in the current directory belong to it, one can simply run (eg. for the `tgv` benchmark):
 ```sh
-julia --project compare.jl $(find . -name "tgv*.json" -printf "%T@ %Tc %p\n" | sort -n | awk '{print $8}') --sort=1
+julia --project compare.jl $(find . -name "tgv*.json" -printf "%T@ %Tc %p\n" | sort -n | awk '{print $7}') --sort=1
 ```
 which would take all the `tgv` JSON files, sort them by creation time, and pass them as arguments to the `compare.jl` program. Finally, note that the first benchmark passed as argument is taken as reference to compute speedups of other benchmarks: `speedup_x = time(benchmark_1) / time(benchmark_x)`. The `--sort=<1 to 8>` argument can also be used when running the comparison. It will sort the benchmark table rows by the values corresponding to the column index passed as argument. `--sort=1` corresponds to sorting by backend. The baseline row is highlighted in blue, and the fastest run in a table is highlighted in green.

--- a/benchmark/benchmark.jl
+++ b/benchmark/benchmark.jl
@@ -52,7 +52,6 @@ function benchmark()
         println("Benchmarking: $(case)")
         suite = BenchmarkGroup()
         results = BenchmarkGroup([case, "sim_step!", p, s, ft, backend_str[backend], git_hash, string(VERSION)])
-        sim_step!(getf(case)(p[1], backend; T=ft), typemax(ft); max_steps=1, verbose=false, remeasure=false) # warm up
         add_to_suite!(suite, getf(case); p=p, s=s, ft=ft, backend=backend) # create benchmark
         results[backend_str[backend]] = run(suite[backend_str[backend]], samples=1, evals=1, seconds=1e6, verbose=true) # run!
         fname = "$(case)_$(p...)_$(s)_$(ft)_$(backend_str[backend])_$(git_hash)_$VERSION.json"

--- a/benchmark/util.jl
+++ b/benchmark/util.jl
@@ -28,8 +28,9 @@ function add_to_suite!(suite, sim_function; p=(3,4,5), s=100, ft=Float32, backen
     suite[bstr] = BenchmarkGroup([bstr])
     for n in p
         sim = sim_function(n, backend; T=ft)
+        sim_step!(sim, typemax(ft); max_steps=1, verbose=false, remeasure=false) # warm up
         suite[bstr][repr(n)] = BenchmarkGroup([repr(n)])
-        @add_benchmark sim_step!($sim, $typemax($ft); max_steps=$s, verbose=false, remeasure=false) $(get_backend(sim.flow.p)) suite[bstr][repr(n)] "sim_step!"
+        @add_benchmark sim_step!($sim, $typemax($ft); max_steps=$s, verbose=true, remeasure=false) $(get_backend(sim.flow.p)) suite[bstr][repr(n)] "sim_step!"
     end
 end
 

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -33,7 +33,7 @@ include("Metrics.jl")
 Constructor for a WaterLily.jl simulation:
 
   - `dims`: Simulation domain dimensions.
-  - `u_BC`: Simulation domain velocity boundary conditions, either a 
+  - `u_BC`: Simulation domain velocity boundary conditions, either a
             tuple `u_BC[i]=uᵢ, i=eachindex(dims)`, or a time-varying function `f(i,t)`
   - `L`: Simulation length scale.
   - `U`: Simulation velocity scale.
@@ -90,7 +90,8 @@ If `remeasure=true`, the body is remeasured at every time step.
 Can be set to `false` for static geometries to speed up simulation.
 """
 function sim_step!(sim::Simulation,t_end;remeasure=true,max_steps=typemax(Int),verbose=false)
-    while sim_time(sim) < t_end && length(sim.flow.Δt) <= max_steps
+    steps₀ = length(sim.flow.Δt)
+    while sim_time(sim) < t_end && length(sim.flow.Δt) - steps₀ < max_steps
         sim_step!(sim; remeasure)
         verbose && println("tU/L=",round(sim_time(sim),digits=4),
             ", Δt=",round(sim.flow.Δt[end],digits=3))


### PR DESCRIPTION
Small benchmark fixes, and `sim_step!` can now be called more than one time and it will always perform additional `max_steps` steps (always up to `t_end` simulation time).