### PR TITLE
add interp routine

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -207,3 +207,29 @@ function `f(i,t)` or the tuple of boundary conditions f=(fₓ,...).
 """
 BCTuple(f::Function,t,N)=ntuple(i->f(i,t),N)
 BCTuple(f::Tuple,t,N)=f
+"""
+    interp(x::SVector, arr::AbstractArray)
+
+    Linear interpolation from array `arr` at index-coordinate `x`.
+    Note: This routine works for any number of dimensions.
+"""
+function interp(x::SVector{D,T}, arr::AbstractArray{T,D}) where {D,T}
+    # Index below the interpolation coordinate and the difference
+    i = floor.(Int,x); y = x.-i
+    
+    # CartesianIndices around x 
+    I = CartesianIndex(i...); R = I:I+oneunit(I)
+
+    # Linearly weighted sum over arr[R] (in serial)
+    s = zero(T)
+    @fastmath @inbounds @simd for J in R
+        weight = prod(@. ifelse(J.I==I.I,1-y,y))
+        s += arr[J]*weight
+    end
+    return s
+end
+function interp(x::SVector{D,T}, varr::AbstractArray{T}) where {D,T}
+    # Shift to align with each staggered grid component and interpolate
+    @inline shift(i) = SVector{D,T}(ifelse(i==j,0.5,0.) for j in 1:D)
+    return SVector{D,T}(interp(x+shift(i),@view(varr[..,i])) for i in 1:D)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,6 +72,14 @@ arrays = setup_backends()
         BC!(u,U,true,(1,)) #saveexit has no effect here as x-periodic
         @test GPUArrays.@allowscalar all(u[1:2, :, 1] .== u[end-1:end, :, 1]) && all(u[1:2, :, 2] .== u[end-1:end, :, 2]) &&
                            all(u[:, 1, 2] .== U[2]) && all(u[:, 2, 2] .== U[2]) && all(u[:, end, 2] .== U[2])
+
+        # test interpolation
+        a = zeros(5,5,2) |> f; b = zeros(5,5) |> f
+        apply!((i,x)->x[i]+1.5,a); apply!(x->x[1]+1.5,b) # offset for start of grid
+        @test GPUArrays.@allowscalar all(WaterLily.interp(SVector(2.5,1),a) .≈ [2.5,1.])
+        @test GPUArrays.@allowscalar all(WaterLily.interp(SVector(3.5,3),a) .≈ [3.5,3.])
+        @test GPUArrays.@allowscalar WaterLily.interp(SVector(2.5,1),b) ≈ 2.5
+        @test GPUArrays.@allowscalar WaterLily.interp(SVector(3.5,3),b) ≈ 3.5
     end
 end
 


### PR DESCRIPTION
This adds the field interpolation routine that will be required for the `Parametricbodies.∮nds`

I also wrote a very simple test for the routine.