### PR TITLE
Fix the issue when calculating λ₂ by using Hermitian matrix

### DIFF
--- a/src/Metrics.jl
+++ b/src/Metrics.jl
@@ -29,7 +29,7 @@ less accurately than inline terms because of the staggered grid.
         @inbounds(u[I+δ(j,I),i]+u[I+δ(j,I)+δ(i,I),i]
                  -u[I-δ(j,I),i]-u[I-δ(j,I)+δ(i,I),i])/4)
 
-using LinearAlgebra: eigvals
+using LinearAlgebra: eigvals, Hermitian
 """
     λ₂(I::CartesianIndex{3},u)
 
@@ -40,7 +40,7 @@ Jeong, J., & Hussain, F., doi:[10.1017/S0022112095000462](https://doi.org/10.101
 function λ₂(I::CartesianIndex{3},u)
     J = @SMatrix [∂(i,j,I,u) for i ∈ 1:3, j ∈ 1:3]
     S,Ω = (J+J')/2,(J-J')/2
-    eigvals(S^2+Ω^2)[2]
+    eigvals(Hermitian(S^2+Ω^2))[2]
 end
 
 """


### PR DESCRIPTION
When calculating lambda2, `S^2+Ω^2` is not always guaranteed to be Hermitian due to floating point error. This will cause issue when calculating its eigen value, especially for MacOS system.

In this regards, forcing the matrix be Hermitian fixes the issue. Furthermore, this won't hurt the performance. I even see some gain in MacOS. You could run the following code several times.

```julia
using LinearAlgebra, StaticArrays, BenchmarkTools

a = @SMatrix rand(3,3)
traceA = tr(a)
b = a .- traceA # make it traceless

# old
function λ₂old(J)
    S,Ω = (J+J')/2,(J-J')/2; eigvals(S^2+Ω^2)[2]
end

# new
function λ₂new(J)
    S,Ω = (J+J')/2,(J-J')/2; eigvals(Hermitian(S^2+Ω^2))[2]
end

println("The one without Hermitian:")
@btime λ₂old($b)
println("The one with Hermitian:")
@btime λ₂new($b)
```

output (Fedora 39 with Intel i7-1265U):
```
The one without Hermitian:
  71.422 ns (0 allocations: 0 bytes)
The one with Hermitian:
  70.319 ns (0 allocations: 0 bytes)
```

output (MacOS 14.4.1 with M1 Pro):
```
The one without Hermitian:
  80.576 ns (0 allocations: 0 bytes)
The one with Hermitian:
  54.272 ns (0 allocations: 0 bytes)
```



