### PR TITLE
Pressure solver for Float32

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "WaterLily"
 uuid = "ed894a53-35f9-47f1-b17f-85db9237eebd"
 authors = ["Gabriel Weymouth <gabriel.weymouth@gmail.com>"]
-version = "1.1"
+version = "1.1.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
@@ -9,6 +9,7 @@ EllipsisNotation = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -153,6 +153,7 @@ and the `AbstractPoisson` pressure solver to project the velocity onto an incomp
 @fastmath function mom_step!(a::Flow{N},b::AbstractPoisson) where N
     a.u⁰ .= a.u; scale_u!(a,0)
     # predictor u → u'
+    @debug "mlp"
     U = BCTuple(a.U,@view(a.Δt[1:end-1]),N)
     conv_diff!(a.f,a.u⁰,a.σ,ν=a.ν,perdir=a.perdir)
     accelerate!(a.f,@view(a.Δt[1:end-1]),a.g,a.U)
@@ -160,6 +161,7 @@ and the `AbstractPoisson` pressure solver to project the velocity onto an incomp
     a.exitBC && exitBC!(a.u,a.u⁰,U,a.Δt[end]) # convective exit
     project!(a,b); BC!(a.u,U,a.exitBC,a.perdir)
     # corrector u → u¹
+    @debug "mlc"
     U = BCTuple(a.U,a.Δt,N)
     conv_diff!(a.f,a.u,a.σ,ν=a.ν,perdir=a.perdir)
     accelerate!(a.f,a.Δt,a.g,a.U)

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,4 +1,20 @@
 using KernelAbstractions: get_backend, @index, @kernel
+using LoggingExtras
+
+"""
+    logger(fname="WaterLily")
+
+Set up a logger to write the pressure solver data to a logging file named `WaterLily.log`.
+"""
+function logger(fname::String="WaterLily")
+    ENV["JULIA_DEBUG"] = all
+    logger = FormatLogger(fname*".log"; append=false) do io, args
+        (args.level <= Logging.Debug && args.message[1:2]=="ml" ) && print(io, args.message[3:end])
+    end;
+    global_logger(logger);
+    # put header file
+    @debug "mlp/c, iter, r∞⁰,r∞, r₂⁰, r₂\n"
+end
 
 @inline CI(a...) = CartesianIndex(a...)
 """

--- a/test/test_psolver.jl
+++ b/test/test_psolver.jl
@@ -1,0 +1,78 @@
+using WaterLily
+using StaticArrays
+using BiotSavartBCs
+using LoggingExtras
+
+"""Circle function"""
+function circle(L=32;m=6,n=4,Re=80,U=1,T=Float32)
+    radius, center = L/2, max(n*L/2,L)
+    body = AutoBody((x,t)->√sum(abs2, x .- center) - radius)
+    Simulation((m*L,n*L), (U,0), radius; ν=U*radius/Re, body, T)
+end
+
+include("../examples/TwoD_plots.jl")
+
+# # # hydrostatic pressure force
+# f1=[]; f2=[]; f3=[]; resolutions = [16,32,64,128,256,512]
+# for N ∈ resolutions
+#     a = Flow((N,N),(1.,0.);f=Array,T=Float32)
+#     sdf(x,t) = √sum(abs2,x.-N÷2)-N÷4
+#     map(x,t) = x.-SVector(t,0)
+#     body = AutoBody(sdf,map)
+#     WaterLily.measure!(a,body)
+#     @inside a.p[I] = loc(0,I)[2]
+#     # @inside a.p[I] = sdf(loc(0,I),0) >= 0 ? loc(0,I)[2] : 0
+#     push!(f1,WaterLily.pressure_force(a,body)/(π*(N÷4)^2))
+# end
+# plot(title="Hydrostatic pressure force",xlabel="N",ylabel="force/πR²")
+# plot!(resolutions,reduce(hcat,f1)[2,:],label="WaterLily.pressure_force(sim)")
+# savefig("hydrostatic_force.png")
+
+# make the sim
+body = AutoBody((x,t)->√sum(abs2,x.-N÷2)-N÷4,(x,t)->x.-SVector(t,0))
+sim = circle(64;m=24,n=16,Re=80,U=1,T=Float32)
+# ml_ω = MLArray(sim.flow.σ)
+
+# allows logging the pressure solver results
+WaterLily.logger("test_psolver")
+
+# intialize
+t₀ = sim_time(sim); duration = 10; tstep = 0.1
+forces_p = []; forces_ν = []
+
+# step and plot
+anim  = @animate for tᵢ in range(t₀,t₀+duration;step=tstep)
+    # update until time tᵢ in the background
+    t = sum(sim.flow.Δt[1:end-1])
+    while t < tᵢ*sim.L/sim.U
+
+        # update flow
+        mom_step!(sim.flow,sim.pois)
+        # biot_mom_step!(sim.flow,sim.pois,ml_ω)
+        
+        # pressure force
+        force = -2WaterLily.pressure_force(sim)
+        push!(forces_p,force)
+        vforce = -2WaterLily.viscous_force(sim)
+        push!(forces_ν,vforce)
+        # update time
+        t += sim.flow.Δt[end]
+    end
+  
+    # print time step
+    println("tU/L=",round(tᵢ,digits=4),",  Δt=",round(sim.flow.Δt[end],digits=3))
+    a = sim.flow.σ;
+    @inside a[I] = WaterLily.curl(3,I,sim.flow.u)*sim.L/sim.U
+    flood(a[inside(a)],clims=(-10,10), legend=false); body_plot!(sim)
+    contour!(sim.flow.p[inside(a)]',levels=range(-1,1,length=10),
+             color=:black,linewidth=0.5,legend=false)
+    # flood(sim.flow.p[inside(a)],clims=(-1,1)); body_plot!(sim)
+    # plot!([100],[200],marker=:o,color=:red,markersize=2,legend=false)
+end
+gif(anim, "cylinder_Float32_FullV.gif", fps = 10)
+time = cumsum(sim.flow.Δt[4:end-1])
+forces_p = reduce(vcat,forces_p')
+forces_ν = reduce(vcat,forces_ν')
+plot(time/sim.L,forces_p[4:end,1]/(sim.L),label="pressure force")
+plot!(time/sim.L,forces_ν[4:end,1]/(sim.L),label="viscous force")
+xlabel!("tU/L"); ylabel!("force/L"); savefig("cylinder_force_Float32_FullV.png")


### PR DESCRIPTION
This is a draft pull request that implements some changes in the pressure solver.

Changes:

- add `@debug` via `LoggingExtras.jl` to monitor the pressure residuals, iterations, etc.
- remove the adaptive multilevel pressure solver and increase the size of the smallest domain to N>=8
- add a test of the impulsive flow around a cylinder to check the pressure forces and oscillations in the pressure field.

Things to do:

- [ ] custom logging to free the `@debug` macro and use `@logmsg` instead for the pressure logging, see https://github.com/JuliaLogging/LoggingExtras.jl
- [ ] Type dispatch of the adaptive/non-adaptive multilevel pressure solver depending on the precision?
- [ ] some proper pressure solve tests
