### PR TITLE
Make Simulation mutable and loc(T=Float32)

### DIFF
--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -55,7 +55,7 @@ Constructor for a WaterLily.jl simulation:
 
 See files in `examples` folder for examples.
 """
-struct Simulation
+mutable struct Simulation
     U :: Number # velocity scale
     L :: Number # length scale
     ϵ :: Number # kernel width

--- a/src/util.jl
+++ b/src/util.jl
@@ -134,7 +134,7 @@ using StaticArrays
 Location in space of the cell at CartesianIndex `I` at face `i`.
 Using `i=0` returns the cell center s.t. `loc = I`.
 """
-@inline loc(i,I::CartesianIndex{N}) where N = SVector{N}(I.I .- 1.5 .- 0.5 .* δ(i,I).I)
+@inline loc(i,I::CartesianIndex{N},T=Float32) where N = SVector{N,T}(I.I .- 1.5 .- 0.5 .* δ(i,I).I)
 @inline loc(Ii::CartesianIndex) = loc(last(Ii),Base.front(Ii))
 Base.last(I::CartesianIndex) = last(I.I)
 Base.front(I::CartesianIndex) = CI(Base.front(I.I))

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -282,7 +282,7 @@ end
 end
 import WaterLily: ×
 @testset "Metrics.jl" begin
-    J = CartesianIndex(2,3,4); x = loc(0,J); px = prod(x)
+    J = CartesianIndex(2,3,4); x = loc(0,J,Float64); px = prod(x)
     for f ∈ arrays
         u = zeros(3,4,5,3) |> f; apply!((i,x)->x[i]+prod(x),u)
         p = zeros(3,4,5) |> f


### PR DESCRIPTION
Made the Simulation type mutable and made `loc` return a Float32 by default. These change help ParametricBodies run on GPUs.

I think the difference is in the noise, but maybe @b-fg should double check...