### PR TITLE
Custom body force

### DIFF
--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -150,7 +150,7 @@ end
 Integrate the `Flow` one time step using the [Boundary Data Immersion Method](https://eprints.soton.ac.uk/369635/)
 and the `AbstractPoisson` pressure solver to project the velocity onto an incompressible flow.
 """
-@fastmath function mom_step!(a::Flow{N},b::AbstractPoisson) where N
+@fastmath function mom_step!(a::Flow{N},b::AbstractPoisson; CFL_f=CFL) where N
     a.u⁰ .= a.u; scale_u!(a,0)
     # predictor u → u'
     U = BCTuple(a.U,@view(a.Δt[1:end-1]),N)
@@ -165,7 +165,7 @@ and the `AbstractPoisson` pressure solver to project the velocity onto an incomp
     accelerate!(a.f,a.Δt,a.g,a.U)
     BDIM!(a); scale_u!(a,0.5); BC!(a.u,U,a.exitBC,a.perdir)
     project!(a,b,0.5); BC!(a.u,U,a.exitBC,a.perdir)
-    push!(a.Δt,CFL(a))
+    push!(a.Δt,CFL_f(a))
 end
 scale_u!(a,scale) = @loop a.u[Ii] *= scale over Ii ∈ inside_u(size(a.p))
 

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -157,7 +157,7 @@ end
 Integrate the `Flow` one time step using the [Boundary Data Immersion Method](https://eprints.soton.ac.uk/369635/)
 and the `AbstractPoisson` pressure solver to project the velocity onto an incompressible flow.
 """
-@fastmath function mom_step!(a::Flow{N},b::AbstractPoisson; bf=nothing, CFL_f=CFL) where N
+@fastmath function mom_step!(a::Flow{N},b::AbstractPoisson; bf=nothing) where N
     a.u⁰ .= a.u; scale_u!(a,0)
     # predictor u → u'
     @log "p"
@@ -176,7 +176,7 @@ and the `AbstractPoisson` pressure solver to project the velocity onto an incomp
     accelerate!(a.f,a.Δt,a.g,a.U)
     BDIM!(a); scale_u!(a,0.5); BC!(a.u,U,a.exitBC,a.perdir)
     project!(a,b,0.5); BC!(a.u,U,a.exitBC,a.perdir)
-    push!(a.Δt,CFL_f(a))
+    push!(a.Δt,CFL(a))
 end
 scale_u!(a,scale) = @loop a.u[Ii] *= scale over Ii ∈ inside_u(size(a.p))
 

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -97,7 +97,7 @@ Can be set to `false` for static geometries to speed up simulation.
 function sim_step!(sim::Simulation,t_end;remeasure=true,max_steps=typemax(Int),bf=nothing,CFL_f=CFL,verbose=false)
     steps₀ = length(sim.flow.Δt)
     while sim_time(sim) < t_end && length(sim.flow.Δt) - steps₀ < max_steps
-        sim_step!(sim; remeasure, CFL_f)
+        sim_step!(sim; remeasure, bf, CFL_f)
         verbose && println("tU/L=",round(sim_time(sim),digits=4),
             ", Δt=",round(sim.flow.Δt[end],digits=3))
     end

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -94,17 +94,17 @@ Integrate the simulation `sim` up to dimensionless time `t_end`.
 If `remeasure=true`, the body is remeasured at every time step.
 Can be set to `false` for static geometries to speed up simulation.
 """
-function sim_step!(sim::Simulation,t_end;remeasure=true,max_steps=typemax(Int),verbose=false)
+function sim_step!(sim::Simulation,t_end;remeasure=true,max_steps=typemax(Int),verbose=false,CFL_f=CFL)
     steps₀ = length(sim.flow.Δt)
     while sim_time(sim) < t_end && length(sim.flow.Δt) - steps₀ < max_steps
-        sim_step!(sim; remeasure)
+        sim_step!(sim; remeasure, CFL_f)
         verbose && println("tU/L=",round(sim_time(sim),digits=4),
             ", Δt=",round(sim.flow.Δt[end],digits=3))
     end
 end
-function sim_step!(sim::Simulation;remeasure=true)
+function sim_step!(sim::Simulation;remeasure=true,CFL_f=CFL)
     remeasure && measure!(sim)
-    mom_step!(sim.flow,sim.pois)
+    mom_step!(sim.flow,sim.pois; CFL_f)
 end
 
 """

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -94,17 +94,17 @@ Integrate the simulation `sim` up to dimensionless time `t_end`.
 If `remeasure=true`, the body is remeasured at every time step.
 Can be set to `false` for static geometries to speed up simulation.
 """
-function sim_step!(sim::Simulation,t_end;remeasure=true,max_steps=typemax(Int),bf=nothing,CFL_f=CFL,verbose=false)
+function sim_step!(sim::Simulation,t_end;remeasure=true,max_steps=typemax(Int),bf=nothing,verbose=false)
     steps₀ = length(sim.flow.Δt)
     while sim_time(sim) < t_end && length(sim.flow.Δt) - steps₀ < max_steps
-        sim_step!(sim; remeasure, bf, CFL_f)
+        sim_step!(sim; remeasure, bf)
         verbose && println("tU/L=",round(sim_time(sim),digits=4),
             ", Δt=",round(sim.flow.Δt[end],digits=3))
     end
 end
-function sim_step!(sim::Simulation;remeasure=true,bf=nothing,CFL_f=CFL)
+function sim_step!(sim::Simulation;remeasure=true,bf=nothing)
     remeasure && measure!(sim)
-    mom_step!(sim.flow,sim.pois; bf, CFL_f)
+    mom_step!(sim.flow,sim.pois; bf)
 end
 
 """

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -94,7 +94,7 @@ Integrate the simulation `sim` up to dimensionless time `t_end`.
 If `remeasure=true`, the body is remeasured at every time step.
 Can be set to `false` for static geometries to speed up simulation.
 """
-function sim_step!(sim::Simulation,t_end;remeasure=true,max_steps=typemax(Int),verbose=false,CFL_f=CFL)
+function sim_step!(sim::Simulation,t_end;remeasure=true,max_steps=typemax(Int),bf=nothing,CFL_f=CFL,verbose=false)
     steps₀ = length(sim.flow.Δt)
     while sim_time(sim) < t_end && length(sim.flow.Δt) - steps₀ < max_steps
         sim_step!(sim; remeasure, CFL_f)
@@ -102,9 +102,9 @@ function sim_step!(sim::Simulation,t_end;remeasure=true,max_steps=typemax(Int),v
             ", Δt=",round(sim.flow.Δt[end],digits=3))
     end
 end
-function sim_step!(sim::Simulation;remeasure=true,CFL_f=CFL)
+function sim_step!(sim::Simulation;remeasure=true,bf=nothing,CFL_f=CFL)
     remeasure && measure!(sim)
-    mom_step!(sim.flow,sim.pois; CFL_f)
+    mom_step!(sim.flow,sim.pois; bf, CFL_f)
 end
 
 """


### PR DESCRIPTION
These are small improvements to allow greater control of the time integration loop. Users can define custom CFL functions and pass arbitrary body forces.

A trivial case is to use a constant time step
```julia
CFL_ct(a::Flow) = 0.25
sim_step!(sim; CFL_f=CFL_ct)
```

Also body forces can be passed to the RHS easily with
```julia
random_force = randn(size(sim.flow.f))
sim_step!(sim; bf=random_force)
```
