### PR TITLE
Fix BCTuple

### DIFF
--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -151,10 +151,9 @@ Integrate the `Flow` one time step using the [Boundary Data Immersion Method](ht
 and the `AbstractPoisson` pressure solver to project the velocity onto an incompressible flow.
 """
 @fastmath function mom_step!(a::Flow{N},b::AbstractPoisson) where N
-    a.u⁰ .= a.u; scale_u!(a,0)
+    a.u⁰ .= a.u; scale_u!(a,0); U = BCTuple(a.U,a.Δt,N)
     # predictor u → u'
     @log "p"
-    U = BCTuple(a.U,@view(a.Δt[1:end-1]),N)
     conv_diff!(a.f,a.u⁰,a.σ,ν=a.ν,perdir=a.perdir)
     accelerate!(a.f,@view(a.Δt[1:end-1]),a.g,a.U)
     BDIM!(a); BC!(a.u,U,a.exitBC,a.perdir)
@@ -162,7 +161,6 @@ and the `AbstractPoisson` pressure solver to project the velocity onto an incomp
     project!(a,b); BC!(a.u,U,a.exitBC,a.perdir)
     # corrector u → u¹
     @log "c"
-    U = BCTuple(a.U,a.Δt,N)
     conv_diff!(a.f,a.u,a.σ,ν=a.ν,perdir=a.perdir)
     accelerate!(a.f,a.Δt,a.g,a.U)
     BDIM!(a); scale_u!(a,0.5); BC!(a.u,U,a.exitBC,a.perdir)

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -300,6 +300,21 @@ end
         )
     end
 end
+
+@testset "Circle in accelerating flow" begin
+    for f ∈ arrays
+        make_accel_circle(radius=32,H=16) = Simulation(radius.*(2H,2H), 
+            (i,t)-> i==1 ? t : zero(t), radius; U=1, mem=f,
+            body=AutoBody((x,t)->√sum(abs2,x .-H*radius)-radius))
+        sim = make_accel_circle(); sim_step!(sim)
+        @test isapprox(WaterLily.pressure_force(sim)/(π*sim.L^2),[-1,0],atol=0.04)
+        @test maximum(sim.flow.u)/sim.flow.u[2,2,1] > 1.91 # ≈ 2U
+        foreach(i->sim_step!(sim),1:3)
+        @test all(sim.pois.n .≤ 2)
+        @test !any(isnan.(sim.pois.n))
+    end
+end
+
 import WaterLily: ×
 @testset "Metrics.jl" begin
     J = CartesianIndex(2,3,4); x = loc(0,J,Float64); px = prod(x)


### PR DESCRIPTION
Evaluating `BCTuple` with t=t_0 in the predictor and t=t_0+dt in the corrector causes a mismatch between the BCs and the residuals (which integrate up to t_0+dt in both steps). This makes the pressure solver extremely unhappy (especially on very large grids) and results in an incorrect pressure field.

This routine just sets `U=Ui(t_0+dt)` for the whole time step and adds a simple 2D test to make sure the solver recovers the potential flow solution for accelerating background flows efficiently. I've also tested this in 3D and on disks and it works consistently.