### PR TITLE
Better restart field specification for ReadVTK extension

### DIFF
--- a/ext/WaterLilyReadVTKExt.jl
+++ b/ext/WaterLilyReadVTKExt.jl
@@ -20,9 +20,8 @@ The time step is also updated to match the time step of the vtk file, such that 
 Keyword arguments considered are `fname="WaterLily.pvd"` and `attrib=default_attrib()`.
 """
 function load!(a::AbstractSimulation, ::Val{:pvd}; kwargs...)
-    kwargs_dict = Dict(kwargs)
-    fname = get(kwargs_dict, :fname, "WaterLily.pvd")
-    attrib = get(kwargs_dict, :attrib, default_attrib())
+    fname = get(Dict(kwargs), :fname, "WaterLily.pvd")
+    attrib = get(Dict(kwargs), :attrib, default_attrib())
     vtk = VTKFile(PVDFile(fname).vtk_filenames[end])
     extent = filter(!iszero,ReadVTK.get_whole_extent(vtk)[2:2:end]);
     # check dimensions match
@@ -30,8 +29,8 @@ function load!(a::AbstractSimulation, ::Val{:pvd}; kwargs...)
     @assert extent.+1 == collect(size(a.flow.p)) text
     # fill the arrays for pressure and velocity
     point_data = ReadVTK.get_point_data(vtk)
-    pressure = get(kwargs_dict, :pressure, "Pressure")
-    velocity = get(kwargs_dict, :velocity, "Velocity")
+    pressure = get(Dict(kwargs), :pressure, "Pressure")
+    velocity = get(Dict(kwargs), :velocity, "Velocity")
     copyto!(a.flow.p, WaterLily.squeeze(Array(get_data_reshaped(point_data[pressure]))));
     copyto!(a.flow.u, WaterLily.squeeze(components_last(Array(get_data_reshaped(point_data[velocity])))));
     # reset time to work with the new time step


### PR DESCRIPTION
The previous writer was only able to read the `pvd` file if it had a `"Pressure"` and `"Velocity"` field in it, but since users can use arbitrary names for these fields in the writer, the reader was breaking in some cases.

This PR implements going through the `kwargs_dict` to grab the custom field names for the restart.

I've looked into the `JLD2` extension and it does not require this fix since there is no control over the name of the field saved.