### PR TITLE
Added PixelBody

### DIFF
--- a/ext/WaterLilyPlotsExt.jl
+++ b/ext/WaterLilyPlotsExt.jl
@@ -22,9 +22,14 @@ function flood(f::AbstractArray;shift=(0.,0.),cfill=:RdBu_11,clims=(),levels=10,
 end
 
 addbody(x,y;c=:black) = Plots.plot!(Shape(x,y), c=c, legend=false)
-function body_plot!(sim;levels=[0],lines=:black,R=inside(sim.flow.p))
-    WaterLily.measure_sdf!(sim.flow.σ,sim.body,WaterLily.time(sim))
-    contour!(sim.flow.σ[R]'|>Array;levels,lines)
+body_plot!(sim;kwargs...) = body_plot!(sim.flow,sim.body;kwargs...)
+function body_plot!(body,flow;levels=[0],c=:black,R=inside(flow.p))
+    WaterLily.measure_sdf!(flow.σ,body,time(flow))
+    contour!(flow.σ[R]'|>Array;levels,lines=c)
+end
+function body_plot!(body::WaterLily.PixelBody,flow;R=inside(flow.p),c=:black)
+    W,H = size(body.mask);
+    heatmap!(range(1,size(R,2),H),range(1,size(R,1),W),ones(Int,H,W),alpha=body.mask'|>Array;c)
 end
 
 """

--- a/src/Body.jl
+++ b/src/Body.jl
@@ -115,41 +115,50 @@ The body fills the zeroth-moment `flow.μ₀` by integrating the mask over a `fl
 leaves the first-moment `μ₁` and velocity `V` zero. Call `update!(body,mask)` with a new mask before 
 calling `measure!(flow,body)` to update the simulation.
 """
-struct PixelBody{T,A<:AbstractArray{T,2}} <: AbstractBody
+struct PixelBody{T,A<:AbstractArray{T,2},B<:AbstractArray{T,3}} <: AbstractBody
     R::CartesianIndices # subarray range
-    mask::A; buff::A # integrated mask and ping-pong buffer
-    function PixelBody(mask::AbstractArray{T,2},dims::NTuple{2,Int};mem=Array) where T
+    mask::A; M₀::A; buff₀::A # mask, global zeroth moment, and buffer
+    M₁::B; buff₁::B # global first moment and buffer
+    function PixelBody(mask::AbstractArray{T,2},dims::NTuple{2,Int};mem=Array,Ti=T) where T
         n,m = dims .+ 2
         W,H = size(mask)
         W₀,H₀ = min(W,ceil(Int,n/m*H)),min(H,ceil(Int,m/n*W))
         R = CartesianIndices(((W-W₀)÷2+1:(W+W₀)÷2,(H-H₀)÷2+1:(H+H₀)÷2))
-        buff = mem{T}(undef,size(R)...)
-        a = new{T,typeof(buff)}(R,similar(buff),buff) # uninitialized
+        M₀ = mem{Ti}(undef,size(R)...)   # size of cropped image W₀ x H₀
+        M₁ = mem{Ti}(undef,size(R)...,2) # 2x cropped image W₀ x H₀ x 2
+        a = new{Ti,typeof(M₀),typeof(M₁)}(R,similar(M₀),M₀,similar(M₀),M₁,similar(M₁)) # uninitialized
         update!(a,mask); a # initialize
     end
 end
 function update!(a::PixelBody{T},mask::AbstractArray{T,2}) where T
     copyto!(a.mask,CartesianIndices(a.mask),mask,a.R)
-    cumsum!(a.buff,a.mask,dims=1)
-    cumsum!(a.mask,a.buff,dims=2) # ping-pong
+    a.mask .= 1 .- a.mask # invert to reduce chances of overflow in cumsum
+    cumsum!(a.buff₀,a.mask,dims=1)
+    cumsum!(a.M₀,a.buff₀,dims=2) # ping-pong
+    @inline moment(Ii,mask) = (I=Base.front(Ii); mask[I]*(I.I)[last(Ii)])
+    @loop a.M₁[Ii] = moment(Ii,a.mask) over Ii ∈ CartesianIndices(a.M₁)
+    cumsum!(a.buff₁,a.M₁,dims=1)
+    cumsum!(a.M₁,a.buff₁,dims=2)
 end
 function measure!(a::Flow{2,T},b::PixelBody;ϵ=1,kwargs...) where T
     a.V .= zero(T); a.σ .= one(T); a.μ₀ .= one(T); a.μ₁ .= zero(T) # init
 
-    # zeroth-moment is the volume-fraction of masked pixels within a cell
-    W,H = size(b.mask); n,m = size(a.σ)
-    function vol_frac(ij,mask)
+    # Truncate the global moments over an ϵ-sized box, and scale by the box size
+    W,H = size(b.mask); ratio = √(length(b.mask)/length(a.σ))
+    function vol_frac(ij,μ₀,μ₁,M₀,M₁)
         i,j = ij.I
-        I₀,J₀ = clamp(floor(Int,(i-ϵ)*W/n),1,W),clamp(floor(Int,(j-ϵ)*H/m),1,H)
-        I₁,J₁ = clamp(ceil(Int,(i+ϵ)*W/n),1,W),clamp(ceil(Int,(j+ϵ)*H/m),1,H)
-        dv = T((I₁-I₀)*(J₁-J₀))
-        (mask[I₀,J₀]+mask[I₁,J₁]-mask[I₀,J₁]-mask[I₁,J₀])/dv
+        I₀,J₀ = clamp(floor(Int,(i-ϵ)*ratio),1,W),clamp(floor(Int,(j-ϵ)*ratio),1,H)
+        I₁,J₁ = clamp(ceil(Int,(i+ϵ)*ratio),1,W),clamp(ceil(Int,(j+ϵ)*ratio),1,H)
+        dv = T((I₁-I₀)*(J₁-J₀)) # box size
+        μ₀[i,j] = 1-(M₀[I₀,J₀]+M₀[I₁,J₁]-M₀[I₀,J₁]-M₀[I₁,J₀])/dv
+        μ₁[i,j,:] = ij .* μ₀[i,j] - (M₁[I₀,J₀,:]+M₁[I₁,J₁,:]-M₁[I₀,J₁,:]-M₁[I₁,J₀,:])/(ratio*dv)
     end
-    WaterLily.@loop a.σ[I] = vol_frac(I,b.mask) over I ∈ inside(a.σ,buff=ceil(Int,ϵ))
+    WaterLily.@loop vol_frac(I,a.σ,b.μ₀,b.M₀,b.M₁) over I ∈ inside(a.σ,buff=ceil(Int,ϵ))
 
     # Interpolate to faces
     for i ∈ 1:2
-        WaterLily.@loop a.μ₀[I,i] = WaterLily.ϕ(i,I,a.σ) over I ∈ inside(a.σ)
+        WaterLily.@loop a.μ₁[I,i,:] = 0.5*(a.μ₀[I-δ(i,I),:]+a.μ₀[I,:]) over I ∈ inside(a.σ)
+        WaterLily.@loop a.μ₀[I,i] = 0.5*(a.σ[I-δ(i,I)]+a.σ[I]) over I ∈ inside(a.σ)
     end
     WaterLily.BC!(a.μ₀,zeros(SVector{2,T}),false,a.perdir) # BC on μ₀, don't fill normal component yet
 end

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -278,6 +278,13 @@ end
     @test all(measure(body1,[3.,4.],0.,fastd²=8) .≈ (sdf(body1,[3.,4.],0.,fastd²=9),zeros(2),zeros(2)))
 end
 
+@testset "PixelBody" begin
+    autobody = AutoBody((x,t)->√(x'*x)-16,(x,t) -> x .- 16)
+    p = zeros(32,32); measure_sdf!(p,circ)
+    mask = p .>= 0 |> UInt16
+
+end
+
 function TGVsim(mem;perdir=(1,2),Re=1e8,T=typeof(Re))
     # Define vortex size, velocity, viscosity
     L = 64; κ = T(2π/L); ν = T(1/(κ*Re));


### PR DESCRIPTION
This defines a body using a masking array where 1=fluid and 0=body. 

One fun feature is that the zeroth-moment μ₀ is found by directly measuring the volume fraction of the mask over an ϵ-sized window. So it's technically _more_ accurate than the SDF-based versions. This is done efficiently and in-place with a parallelized `cumsum!` over each index. We ping-pong the operations when calling `update!(body,mask)` on two internal arrays the size of the windowed mask (with that size `M>>N` probably). after which the `measure!(flow,body)` cost is `O(N)`.

To Do:

- [ ] It currently doesn't estimate μ₁ or V. We could directly estimate μ₁ using summation, but it would require more storage. We'll need to pass V in separately, either as a mask or a function if we want it. 

- [ ]  It's currently hard coded to 2D, but it should be extendable to 3D without too much trouble. (Ping-pong -> pong-ping-pong, and I need the 3D version of the difference function). 