### PR TITLE
Removed `@fastmath` in `flux_out` declaration

### DIFF
--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -169,10 +169,10 @@ function CFL(a::Flow;Δt_max=10)
     @inside a.σ[I] = flux_out(I,a.u)
     min(Δt_max,inv(maximum(a.σ)+5a.ν))
 end
-@fastmath @inline function flux_out(I::CartesianIndex{d},u) where {d}
+@inline function flux_out(I::CartesianIndex{d},u) where {d}
     s = zero(eltype(u))
     for i in 1:d
-        s += @inbounds(max(0,u[I+δ(i,I),i])+max(0,-u[I,i]))
+        @inbounds s += max(zero(s),u[I+δ(i,I),i])+max(zero(s),-u[I,i])
     end
     return s
 end

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -331,7 +331,7 @@ function acceleratingFlow(N;use_g=false,T=Float64,perdir=(1,),jerk=4,mem=Array)
     # assuming gravitational scale is 1 and Fr is 1, U scale is Fr*√gL
     UScale = √N  # this is also initial U
     # constant jerk in x, zero acceleration in y
-    g(i,x,t) = i==1 ? t*jerk : 0.
+    g(i,x,t) = i==1 ? t*jerk : zero(t)
     !use_g && (g = nothing)
     return WaterLily.Simulation(
         (N,N), (UScale,0.), N; ν=0.001,g,Δt=0.001,perdir,T,mem


### PR DESCRIPTION
This PR is related to https://github.com/WaterLily-jl/WaterLily.jl/issues/258, and is a follow up of https://github.com/WaterLily-jl/WaterLily.jl/pull/259.

`@fastmath` in `flux_out` declaration was causing a GPU error on tests of acceleration flow. Currently all tests pass locally on CPU and GPU. I am not sure if this will affect performance, so benchmarks need to be run.
