### PR TITLE
Improve performance by replacing broadcasting with built-in function

### DIFF
--- a/src/Body.jl
+++ b/src/Body.jl
@@ -25,7 +25,7 @@ at time `t` using an immersion kernel of size `ϵ`.
 See Maertens & Weymouth, doi:[10.1016/j.cma.2014.09.007](https://doi.org/10.1016/j.cma.2014.09.007).
 """
 function measure!(a::Flow{N,T},body::AbstractBody;t=zero(T),ϵ=1) where {N,T}
-    a.V .= zero(T); a.μ₀ .= one(T); a.μ₁ .= zero(T); d²=(2+ϵ)^2
+    fill!(a.V,0); fill!(a.μ₀,0); fill!(a.μ₁,0); d²=(2+ϵ)^2
     @fastmath @inline function fill!(μ₀,μ₁,V,d,I)
         d[I] = sdf(body,loc(0,I,T),t,fastd²=d²)
         if d[I]^2<d²

--- a/src/Body.jl
+++ b/src/Body.jl
@@ -26,7 +26,7 @@ See Maertens & Weymouth, doi:[10.1016/j.cma.2014.09.007](https://doi.org/10.1016
 """
 function measure!(a::Flow{N,T},body::AbstractBody;t=zero(T),ϵ=1) where {N,T}
     fill!(a.V,0); fill!(a.μ₀,0); fill!(a.μ₁,0); d²=(2+ϵ)^2
-    @fastmath @inline function fill!(μ₀,μ₁,V,d,I)
+    @fastmath @inline function fillμ!(μ₀,μ₁,V,d,I)
         d[I] = sdf(body,loc(0,I,T),t,fastd²=d²)
         if d[I]^2<d²
             for i ∈ 1:N
@@ -43,7 +43,7 @@ function measure!(a::Flow{N,T},body::AbstractBody;t=zero(T),ϵ=1) where {N,T}
             end
         end
     end
-    @loop fill!(a.μ₀,a.μ₁,a.V,a.σ,I) over I ∈ inside(a.p)
+    @loop fillμ!(a.μ₀,a.μ₁,a.V,a.σ,I) over I ∈ inside(a.p)
     BC!(a.μ₀,zeros(SVector{N,T}),false,a.perdir) # BC on μ₀, don't fill normal component yet
     BC!(a.V ,zeros(SVector{N,T}),a.exitBC,a.perdir)
 end

--- a/src/Body.jl
+++ b/src/Body.jl
@@ -25,7 +25,7 @@ at time `t` using an immersion kernel of size `ϵ`.
 See Maertens & Weymouth, doi:[10.1016/j.cma.2014.09.007](https://doi.org/10.1016/j.cma.2014.09.007).
 """
 function measure!(a::Flow{N,T},body::AbstractBody;t=zero(T),ϵ=1) where {N,T}
-    fill!(a.V,0); fill!(a.μ₀,0); fill!(a.μ₁,0); d²=(2+ϵ)^2
+    fill!(a.V,0); fill!(a.μ₀,1); fill!(a.μ₁,0); d²=(2+ϵ)^2
     @fastmath @inline function fillμ!(μ₀,μ₁,V,d,I)
         d[I] = sdf(body,loc(0,I,T),t,fastd²=d²)
         if d[I]^2<d²

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -160,7 +160,7 @@ and the `AbstractPoisson` pressure solver to project the velocity onto an incomp
     conv_diff!(a.f,a.u,a.σ,λ;ν=a.ν,perdir=a.perdir)
     udf!(a,udf,t₁; kwargs...)
     accelerate!(a.f,t₁,a.g,a.uBC)
-    BDIM!(a); rmul!(a,0.5); BC!(a.u,a.uBC,a.exitBC,a.perdir,t₁)
+    BDIM!(a); rmul!(a.u,0.5); BC!(a.u,a.uBC,a.exitBC,a.perdir,t₁)
     project!(a,b,0.5); BC!(a.u,a.uBC,a.exitBC,a.perdir,t₁)
     push!(a.Δt,CFL(a))
 end

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -36,7 +36,7 @@ function median(a,b,c)
 end
 
 function conv_diff!(r,u,Φ,λ::F;ν=0.1,perdir=()) where {F}
-    r .= zero(eltype(r))
+    fill!(r,0)
     N,n = size_u(u)
     for i ∈ 1:n, j ∈ 1:n
         # if it is periodic direction
@@ -128,14 +128,15 @@ function BDIM!(a::Flow)
     @loop a.u[Ii] += μddn(Ii,a.μ₁,a.f)+a.V[Ii]+a.μ₀[Ii]*a.f[Ii] over Ii ∈ inside_u(size(a.p))
 end
 
+import LinearAlgebra: rmul!
 function project!(a::Flow{n},b::AbstractPoisson,w=1) where n
     dt = w*a.Δt[end]
-    @inside b.z[I] = div(I,a.u); b.x .*= dt # set source term & solution IC
+    @inside b.z[I] = div(I,a.u); rmul!(b.x, dt) # set source term & solution IC
     solver!(b)
     for i ∈ 1:n  # apply solution and unscale to recover pressure
         @loop a.u[I,i] -= b.L[I,i]*∂(i,I,b.x) over I ∈ inside(b.x)
     end
-    b.x ./= dt
+    rmul!(b.x, inv(dt))
 end
 
 """
@@ -145,7 +146,7 @@ Integrate the `Flow` one time step using the [Boundary Data Immersion Method](ht
 and the `AbstractPoisson` pressure solver to project the velocity onto an incompressible flow.
 """
 @fastmath function mom_step!(a::Flow{N},b::AbstractPoisson;λ=quick,udf=nothing,kwargs...) where N
-    a.u⁰ .= a.u; scale_u!(a,0); t₁ = sum(a.Δt); t₀ = t₁-a.Δt[end]
+    copyto!(a.u⁰,a.u); scale_u!(a,0); t₁ = sum(a.Δt); t₀ = t₁-a.Δt[end]
     # predictor u → u'
     @log "p"
     conv_diff!(a.f,a.u⁰,a.σ,λ;ν=a.ν,perdir=a.perdir)

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -146,7 +146,7 @@ Integrate the `Flow` one time step using the [Boundary Data Immersion Method](ht
 and the `AbstractPoisson` pressure solver to project the velocity onto an incompressible flow.
 """
 @fastmath function mom_step!(a::Flow{N},b::AbstractPoisson;λ=quick,udf=nothing,kwargs...) where N
-    copyto!(a.u⁰,a.u); scale_u!(a,0); t₁ = sum(a.Δt); t₀ = t₁-a.Δt[end]
+    copyto!(a.u⁰,a.u); fill!(a.u,0); t₁ = sum(a.Δt); t₀ = t₁-a.Δt[end]
     # predictor u → u'
     @log "p"
     conv_diff!(a.f,a.u⁰,a.σ,λ;ν=a.ν,perdir=a.perdir)
@@ -160,11 +160,10 @@ and the `AbstractPoisson` pressure solver to project the velocity onto an incomp
     conv_diff!(a.f,a.u,a.σ,λ;ν=a.ν,perdir=a.perdir)
     udf!(a,udf,t₁; kwargs...)
     accelerate!(a.f,t₁,a.g,a.uBC)
-    BDIM!(a); scale_u!(a,0.5); BC!(a.u,a.uBC,a.exitBC,a.perdir,t₁)
+    BDIM!(a); rmul!(a,0.5); BC!(a.u,a.uBC,a.exitBC,a.perdir,t₁)
     project!(a,b,0.5); BC!(a.u,a.uBC,a.exitBC,a.perdir,t₁)
     push!(a.Δt,CFL(a))
 end
-scale_u!(a,scale) = @loop a.u[Ii] *= scale over Ii ∈ inside_u(size(a.p))
 
 function CFL(a::Flow;Δt_max=10)
     @inside a.σ[I] = flux_out(I,a.u)

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -160,10 +160,11 @@ and the `AbstractPoisson` pressure solver to project the velocity onto an incomp
     conv_diff!(a.f,a.u,a.σ,λ;ν=a.ν,perdir=a.perdir)
     udf!(a,udf,t₁; kwargs...)
     accelerate!(a.f,t₁,a.g,a.uBC)
-    BDIM!(a); rmul!(a.u,0.5); BC!(a.u,a.uBC,a.exitBC,a.perdir,t₁)
+    BDIM!(a); scale_u!(a,0.5); BC!(a.u,a.uBC,a.exitBC,a.perdir,t₁)
     project!(a,b,0.5); BC!(a.u,a.uBC,a.exitBC,a.perdir,t₁)
     push!(a.Δt,CFL(a))
 end
+scale_u!(a,scale) = @loop a.u[Ii] *= scale over Ii ∈ inside_u(size(a.p))
 
 function CFL(a::Flow;Δt_max=10)
     @inside a.σ[I] = flux_out(I,a.u)

--- a/src/Metrics.jl
+++ b/src/Metrics.jl
@@ -102,7 +102,7 @@ pressure_force(sim) = pressure_force(sim.flow,sim.body)
 pressure_force(flow,body) = pressure_force(flow.p,flow.f,body,time(flow))
 function pressure_force(p,df,body,t=0)
     Tp = eltype(p); To = promote_type(Float64,Tp)
-    df .= zero(Tp)
+    fill!(df,0)
     @loop df[I,:] .= p[I]*nds(body,loc(0,I,Tp),t) over I ∈ inside(p)
     sum(To,df,dims=ntuple(i->i,ndims(p)))[:] |> Array
 end
@@ -124,7 +124,7 @@ viscous_force(sim) = viscous_force(sim.flow,sim.body)
 viscous_force(flow,body) = viscous_force(flow.u,flow.ν,flow.f,body,time(flow))
 function viscous_force(u,ν,df,body,t=0)
     Tu = eltype(u); To = promote_type(Float64,Tu)
-    df .= zero(Tu)
+    fill!(df,0)
     @loop df[I,:] .= -2ν*S(I,u)*nds(body,loc(0,I,Tu),t) over I ∈ inside_u(u)
     sum(To,df,dims=ntuple(i->i,ndims(u)-1))[:] |> Array
 end
@@ -146,7 +146,7 @@ pressure_moment(x₀,sim) = pressure_moment(x₀,sim.flow,sim.body)
 pressure_moment(x₀,flow,body) = pressure_moment(x₀,flow.p,flow.f,body,time(flow))
 function pressure_moment(x₀,p,df,body,t=0)
     Tp = eltype(p); To = promote_type(Float64,Tp)
-    df .= zero(Tp)
+    fill!(df,0)
     @loop df[I,:] .= p[I]*cross(loc(0,I,Tp)-x₀,nds(body,loc(0,I,Tp),t)) over I ∈ inside(p)
     sum(To,df,dims=ntuple(i->i,ndims(p)))[:] |> Array
 end
@@ -211,6 +211,6 @@ function uu(a::MeanFlow)
 end
 
 function copy!(a::Flow, b::MeanFlow)
-    a.u .= b.U
-    a.p .= b.P
+    copyto!(a.u,b.U)
+    copyto!(a.p,b.P)
 end


### PR DESCRIPTION
- `A .= B` can be `copyto!(A,B)`. 
- `A .= a` can be `fill!(A,a)`
- `A.*=a` can be `rmul!(A,a)`
- `A./=a` can be `rmul!(A,inv(a))`