### PR TITLE
Add `sym` kwarg to `viz!` for mirroring simulations on visualization

### DIFF
--- a/ext/WaterLilyMakieExt.jl
+++ b/ext/WaterLilyMakieExt.jl
@@ -117,6 +117,10 @@ Keyword arguments:
     - `CIs::CartesianIndices`: Range of Cartesian indices to render.
     - `cut::Tuple{Int, Int, Int}`: For 3D simulation and `d=2`, `cut` provides the plane to render, and defaults to (0,0,N[3]/2).
         It needs to be defined as a Tuple of 0s with a single non-zero entry on the cutting plane.
+    - `sym::Tuple`: Mirror the visualization data for simulations that only model a symmetric half (or quarter/octant) of the
+        full body. Defaults to `nothing` (no mirroring). Length must match the plot dimension `d`. A non-zero entry flags the
+        dimension to mirror: e.g. `d=2, sym=(0,1)` mirrors along the 2nd plot axis; `d=3, sym=(1,1,0)` mirrors along the 1st and
+        2nd plot axes. Both the scalar field and the body SDF are mirrored; the axis `limits` are doubled along mirrored dims.
     - `tidy_colormap::Bool`: Adjusts the colormap to have a fully transparent color near 0 values. Additional plotting options
         passed into `kwargs` (eg. colormap, levels) are preserved.
         Pass `threshhold::Number` to adjust the near-0 range`, `threshhold_color::RGBA` to set to a color different from white, and
@@ -140,17 +144,17 @@ Keyword arguments:
 """
 function viz!(sim; f=nothing, duration=nothing, step=0.1, remeasure=true, verbose=true,
     λ=quick, udf=nothing, udf_kwargs=nothing,
-    d=ndims(sim.flow.p), CIs=nothing, cut=nothing, tidy_colormap=true,
+    d=ndims(sim.flow.p), CIs=nothing, cut=nothing, sym=nothing, tidy_colormap=true,
     body=!(typeof(sim.body)<:WaterLily.NoBody), body_color=:grey, body2mesh=false,
     video=nothing, hidedecorations=false, elevation=π/8, azimuth=1.275π, framerate=60, compression=5,
     theme=nothing, fig_size=nothing, fig_pad=10, fig=nothing, ax=nothing, kwargs...)
 
     function update_data()
         f(dat, sim)
-        σ[] = WaterLily.squeeze(dat[CIs])
+        σ[] = mirror_sym(WaterLily.squeeze(dat[CIs]), sym)
         if body && remeasure
             update_body!(dat, sim)
-            σb_obs[] = get_body(WaterLily.squeeze(dat[CIs]), Val{body2mesh}())
+            σb_obs[] = get_body(mirror_sym(WaterLily.squeeze(dat[CIs]), sym), Val{body2mesh}())
         end
     end
     function step_sim_and_viz!(sim, tᵢ)
@@ -163,6 +167,7 @@ function viz!(sim; f=nothing, duration=nothing, step=0.1, remeasure=true, verbos
     body2mesh && (@assert !isnothing(Base.get_extension(WaterLily, :WaterLilyMeshingExt)) "If body2mesh=true, Meshing must be loaded.")
     D = ndims(sim.flow.σ)
     @assert d <= D "Cannot do a 3D plot on a 2D simulation."
+    !isnothing(sym) && @assert length(sym) == d "sym kwarg must have length equal to plot dimension d=$d, got $(length(sym))."
     !isnothing(udf) && !isnothing(udf_kwargs) && (@assert all(isa(kw, Pair{Symbol}) for kw in udf_kwargs) "udf_kwargs needs to contain Pair{Symbol,Any} elements, eg. Dict{Symbol,Any}.")
     isnothing(udf) && (udf_kwargs=[])
     isnothing(f) && (f = ω_viz!(d))
@@ -176,16 +181,17 @@ function viz!(sim; f=nothing, duration=nothing, step=0.1, remeasure=true, verbos
         CIs = Tuple(i == cut_dim ? (cut[i]:cut[i]) : CIs.indices[i] for i in 1:D) |> CartesianIndices
     end
     limits = Tuple((1,n) for n in size(CIs) if n > 1)
+    !isnothing(sym) && (limits = Tuple(sym[i] != 0 ? (1, 2*lim[2]) : lim for (i, lim) in enumerate(limits)))
     if isnothing(fig_size)
         fig_size = (1200, 1200)
         d == 2 && (fig_size = (fig_size[1], fig_size[2] * (limits[2][2] / limits[1][2])))
     end
 
     f(dat, sim)
-    σ = WaterLily.squeeze(dat[CIs]) |> ad_f(sim) |> Observable
+    σ = mirror_sym(WaterLily.squeeze(dat[CIs]), sym) |> ad_f(sim) |> Observable
     if body
         update_body!(dat, sim)
-        σb_obs = get_body(WaterLily.squeeze(dat[CIs]), Val{body2mesh}()) |> ad_f(sim) |> Observable
+        σb_obs = get_body(mirror_sym(WaterLily.squeeze(dat[CIs]), sym), Val{body2mesh}()) |> ad_f(sim) |> Observable
     end
 
     !isnothing(theme) && set_theme!(theme)
@@ -242,5 +248,21 @@ end
 add_kwarg(args...; kwargs...) = (; kwargs..., (p.first => p.second for p in args)...) |> pairs
 remove_kwargs(args...; kwargs...) = (;(x.first=>x.second for x in kwargs if !in(x.first, args))...) |> pairs
 ad_f(sim) = eltype(sim.flow.p) <: Dual ? x -> value.(x) : identity
+
+"""
+    mirror_sym(arr, sym)
+
+Mirror `arr` along each dimension `i` with `sym[i] != 0` by concatenating `reverse(arr; dims=i)` before `arr`.
+`sym === nothing` returns `arr` unchanged. `length(sym)` must equal `ndims(arr)`.
+"""
+mirror_sym(arr::AbstractArray, ::Nothing) = arr
+function mirror_sym(arr::AbstractArray{T,N}, sym) where {T,N}
+    out = arr
+    for i in 1:N
+        sym[i] == 0 && continue
+        out = cat(reverse(out; dims=i), out; dims=i)
+    end
+    return out
+end
 
 end # module

--- a/ext/WaterLilyMakieExt.jl
+++ b/ext/WaterLilyMakieExt.jl
@@ -12,7 +12,7 @@ Measure the body SDF and update the CPU buffer array.
 """
 function update_body!(a_cpu::Array, sim)
     WaterLily.measure_sdf!(sim.flow.σ, sim.body, WaterLily.time(sim))
-    copyto!(a_cpu, ad_f(sim)(sim.flow.σ[inside(sim.flow.σ)]))
+    copyto!(a_cpu, ad_f(sim)(@view sim.flow.σ[inside(sim.flow.σ)]))
 end
 
 """
@@ -34,12 +34,12 @@ Default visualization function for 2D/3D simulations
 function ω2D_viz!(cpu_array, sim)
     a = sim.flow.σ
     WaterLily.@inside a[I] = WaterLily.curl(3,I,sim.flow.u)
-    copyto!(cpu_array, ad_f(sim)(a[inside(a)]))
+    copyto!(cpu_array, ad_f(sim)(@view a[inside(a)]))
 end
 function ω3D_viz!(cpu_array, sim)
     a = sim.flow.σ
     WaterLily.@inside a[I] = WaterLily.ω_mag(I,sim.flow.u)
-    copyto!(cpu_array, ad_f(sim)(a[inside(a)]))
+    copyto!(cpu_array, ad_f(sim)(@view a[inside(a)]))
 end
 ω_viz!(n) = n == 2 ? ω2D_viz! : ω3D_viz!
 
@@ -151,10 +151,12 @@ function viz!(sim; f=nothing, duration=nothing, step=0.1, remeasure=true, verbos
 
     function update_data()
         f(dat, sim)
-        σ[] = mirror_sym(WaterLily.squeeze(dat[CIs]), sym)
+        mirror_sym!(σ_buf, WaterLily.squeeze(@view dat[CIs]), sym)
+        σ[] = σ_buf
         if body && remeasure
             update_body!(dat, sim)
-            σb_obs[] = get_body(mirror_sym(WaterLily.squeeze(dat[CIs]), sym), Val{body2mesh}())
+            mirror_sym!(σb_buf, WaterLily.squeeze(@view dat[CIs]), sym)
+            σb_obs[] = get_body(σb_buf, Val{body2mesh}())
         end
     end
     function step_sim_and_viz!(sim, tᵢ)
@@ -188,10 +190,16 @@ function viz!(sim; f=nothing, duration=nothing, step=0.1, remeasure=true, verbos
     end
 
     f(dat, sim)
-    σ = mirror_sym(WaterLily.squeeze(dat[CIs]), sym) |> ad_f(sim) |> Observable
+    slice0 = WaterLily.squeeze(@view dat[CIs]) |> ad_f(sim)
+    σ_buf = similar(dat, mirror_size(slice0, sym))
+    mirror_sym!(σ_buf, slice0, sym)
+    σ = Observable(σ_buf)
     if body
         update_body!(dat, sim)
-        σb_obs = get_body(mirror_sym(WaterLily.squeeze(dat[CIs]), sym), Val{body2mesh}()) |> ad_f(sim) |> Observable
+        bslice0 = WaterLily.squeeze(@view dat[CIs]) |> ad_f(sim)
+        σb_buf = similar(dat, mirror_size(bslice0, sym))
+        mirror_sym!(σb_buf, bslice0, sym)
+        σb_obs = Observable(get_body(σb_buf, Val{body2mesh}()))
     end
 
     !isnothing(theme) && set_theme!(theme)
@@ -250,19 +258,40 @@ remove_kwargs(args...; kwargs...) = (;(x.first=>x.second for x in kwargs if !in(
 ad_f(sim) = eltype(sim.flow.p) <: Dual ? x -> value.(x) : identity
 
 """
+    mirror_size(arr, sym)
+
+Size of the mirrored array: each dimension `i` with `sym[i] != 0` is doubled. Returns `size(arr)` if `sym === nothing`.
+"""
+mirror_size(arr::AbstractArray, ::Nothing) = size(arr)
+mirror_size(arr::AbstractArray{T,N}, sym) where {T,N} = ntuple(i -> sym[i] != 0 ? 2*size(arr,i) : size(arr,i), N)
+
+"""
     mirror_sym(arr, sym)
 
-Mirror `arr` along each dimension `i` with `sym[i] != 0` by concatenating `reverse(arr; dims=i)` before `arr`.
-`sym === nothing` returns `arr` unchanged. `length(sym)` must equal `ndims(arr)`.
+Allocating mirror: returns a new array with `arr` reflected along each dimension `i` where `sym[i] != 0`.
+`sym === nothing` returns `arr` unchanged. Use [`mirror_sym!`](@ref) to fill a pre-allocated buffer.
 """
 mirror_sym(arr::AbstractArray, ::Nothing) = arr
 function mirror_sym(arr::AbstractArray{T,N}, sym) where {T,N}
-    out = arr
-    for i in 1:N
-        sym[i] == 0 && continue
-        out = cat(reverse(out; dims=i), out; dims=i)
+    buf = similar(arr, mirror_size(arr, sym))
+    mirror_sym!(buf, arr, sym)
+end
+
+"""
+    mirror_sym!(dst, src, sym)
+
+In-place mirror: fills `dst` from `src` reflected along each dimension `i` where `sym[i] != 0`.
+`dst` must have size `mirror_size(src, sym)`. `sym === nothing` does a plain `copyto!`.
+"""
+mirror_sym!(dst::AbstractArray, src::AbstractArray, ::Nothing) = copyto!(dst, src)
+function mirror_sym!(dst::AbstractArray{T,N}, src::AbstractArray{S,N}, sym) where {T,S,N}
+    Ns = size(src)
+    @inbounds for I in CartesianIndices(dst)
+        J = CartesianIndex(ntuple(i -> sym[i] != 0 ?
+            (I[i] <= Ns[i] ? Ns[i] + 1 - I[i] : I[i] - Ns[i]) : I[i], N))
+        dst[I] = src[J]
     end
-    return out
+    return dst
 end
 
 end # module


### PR DESCRIPTION
## Add `sym` kwarg to `viz!` for mirroring simulations on visualization [Claude assisted]

## Summary

Adds a `sym` keyword argument to `viz!` (in `WaterLilyMakieExt`) that mirrors the scalar field and body SDF for simulations that only model a symmetric fraction of the full body.

- `sym = nothing` (default) → no mirroring; existing behavior preserved.
- `sym::Tuple` of length `d` (plot dim) → non-zero entries flag plot dimensions to mirror.
  - e.g. `d=2, sym=(0,1)` mirrors along the 2nd plot axis.
  - e.g. `d=3, sym=(1,1,0)` mirrors along the 1st and 2nd plot axes.
- Axis `limits` are doubled on mirrored dims so the aspect stays correct.
- Works for both 2D and 3D plots, including 2D cuts of 3D simulations.

Motivation: common symmetric jelly / body simulations are set up in one quadrant/octant to save compute, and today `viz!` renders only that fraction. This kwarg lets the visualization reproduce the full object without the user hand-mirroring arrays.

Inspiration: [ThreeD_Jelly.jl](https://github.com/WaterLily-jl/WaterLily-Examples/blob/9ffa1ffbf141196c048d8dfbe828c53ddf8dcca4/examples/ThreeD_Jelly.jl).

## Implementation notes

- New helpers in `ext/WaterLilyMakieExt.jl`:
  - `mirror_size(arr, sym)` — target shape (doubles flagged dims).
  - `mirror_sym(arr, sym)` — allocating mirror, returns `arr` when `sym === nothing`.
  - `mirror_sym!(dst, src, sym)` — in-place fill by index math, no `cat`/`reverse` allocations.
- `viz!` pre-allocates the mirrored scalar buffer (`σ_buf`) and body buffer (`σb_buf`) once after `CIs` is finalized, then calls `mirror_sym!` each frame.
- Assertion: `length(sym) == d` is checked early with a clear error message.
- `a[inside(a)]` in `ω_viz!` / `update_body!` and `dat[CIs]` in `update_data` now use `@view`s, dropping a few small per-frame allocations.

## Performance (jelly example, `L=2^5`, `duration=5.0`, warm)

| `sym`       | time  | allocs   | alloc size |
|-------------|-------|----------|------------|
| `nothing`   | 16.5s | 50.94M   | 3.604 GiB  |
| `(1,0,0)`   | 17.4s | 50.95M   | 3.657 GiB  |
| `(1,1,1)`   | 18.7s | 50.94M   | 3.966 GiB  |

- Per-frame alloc count is flat across `sym` modes — mirror buffers are allocated once.
- Size growth under `sym` is purely the cost of Makie rendering a 2×/8× larger volume; no per-frame `cat` chain.

## Test plan

- [x] `jelly.jl` (WaterLilyMakieSym.jl sandbox) renders the full body with `sym=(1,1,0)` / `sym=(1,1,1)`.
- [x] `sym=nothing` output is unchanged from pre-PR behavior.
- [x] Run existing WaterLily test suite: `julia --project=. -e 'using Pkg; Pkg.test("WaterLily")'`.
- [x] Sanity-check 2D sim + `sym=(0,1)` contourf render.
- [x] Sanity-check 2D cut of a 3D sim with `sym` set on the remaining plot axes.
- [x] Sanity-check `body2mesh=true` path still works (3D only, unchanged code path).

## Commits

- `d94d5e9` Add `sym` kwarg to viz! for mirroring symmetric sims
- `c9346ba` Reduce viz! allocations under `sym`

### Breaking changes

None. `sym` defaults to `nothing` and all pre-existing call sites behave identically.
