### PR TITLE
Type stable kernels and μ₀ threshold

### DIFF
--- a/src/Body.jl
+++ b/src/Body.jl
@@ -55,6 +55,7 @@ end
 @fastmath kern₀(d::T) where T = (1+d+sinpi(d)/T(π))/2
 @fastmath kern₁(d::T) where T = (1-d^2)/4-(d*sinpi(d)+(1+cospi(d))/T(π))/2T(π)
 
+# Kernel moments truncated at -1+√eps to bound 1/μ₀ in the fluid
 μ₀(d,ϵ) = d/ϵ<-1+√eps(d) ? zero(d) : kern₀(min(d/ϵ,1))
 μ₁(d,ϵ) = ϵ*kern₁(clamp(d/ϵ,-1,1))
 

--- a/src/Body.jl
+++ b/src/Body.jl
@@ -51,11 +51,11 @@ function measure!(a::Flow{N,T},body::AbstractBody;t=zero(T),ϵ=1) where {N,T}
 end
 
 # Convolution kernel and its moments
-@fastmath kern(d) = 0.5+0.5cos(π*d)
-@fastmath kern₀(d) = 0.5+0.5d+0.5sin(π*d)/π
-@fastmath kern₁(d) = 0.25*(1-d^2)-0.5*(d*sin(π*d)+(1+cos(π*d))/π)/π
+@fastmath kern(d) = (1+cospi(d))/2
+@fastmath kern₀(d::T) where T = (1+d+sinpi(d)/T(π))/2
+@fastmath kern₁(d::T) where T = (1-d^2)/4-(d*sinpi(d)+(1+cospi(d))/T(π))/2T(π)
 
-μ₀(d,ϵ) = kern₀(clamp(d/ϵ,-1,1))
+μ₀(d,ϵ) = d/ϵ<-1+√eps(d) ? zero(d) : kern₀(min(d/ϵ,1))
 μ₁(d,ϵ) = ϵ*kern₁(clamp(d/ϵ,-1,1))
 
 """
@@ -101,7 +101,7 @@ Base.:-(a::AbstractBody) = SetBody(-,a,NoBody())
 Base.:-(a::AbstractBody, b::AbstractBody) = a ∩ (-b)
 
 # Measurements
-function measure(body::SetBody,x::AbstractVector{T},t;fastd²=T(Inf)) where T 
+function measure(body::SetBody,x::AbstractVector{T},t;fastd²=T(Inf)) where T
     body.op(measure(body.a,x,t;fastd²),measure(body.b,x,t;fastd²)) # can't mapreduce within GPU kernel
 end
 measure(body::SetBody{typeof(-)},x::AbstractVector{T},t;fastd²=T(Inf)) where T = ((d,n,V) = measure(body.a,x,t;fastd²); (-d,-n,V))

--- a/src/Poisson.jl
+++ b/src/Poisson.jl
@@ -42,7 +42,7 @@ using ForwardDiff: Dual,Tag
 Base.eps(::Type{D}) where D<:Dual{Tag{G,T}} where {G,T} = eps(T)
 function set_diag!(D,iD,L)
     @inside D[I] = diag(I,L)
-    @inside iD[I] = abs2(D[I])<2eps(eltype(D)) ? 0. : inv(D[I])
+    @inside iD[I] = iszero(D[I]) ? D[I] : inv(D[I])
 end
 update!(p::Poisson) = set_diag!(p.D,p.iD,p.L)
 

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -235,9 +235,10 @@ end
 end
 
 @testset "Body.jl" begin
-    @test WaterLily.μ₀(3,6)==WaterLily.μ₀(0.5,1)
-    @test WaterLily.μ₀(0,1)==0.5
-    @test WaterLily.μ₁(0,2)==2*(1/4-1/π^2)
+    @test WaterLily.μ₀(3.,6)==WaterLily.μ₀(0.5,1)
+    @test WaterLily.μ₀(0.,1)==0.5
+    @test WaterLily.μ₀(eps(1.)-1,1)==0
+    @test WaterLily.μ₁(0.,2)==2*(1/4-1/π^2)
 
     @test all(measure(WaterLily.NoBody(),[2,1],0) .== (Inf,zeros(2),zeros(2)))
     @test sdf(WaterLily.NoBody(),[2,1],0) == Inf


### PR DESCRIPTION
The threshold on `iD` was putting it "out of sync" with the values of `D` and `L`. This PR tries a different approach, applying a threshold `μ₀(d)` to avoid tiny non-zero values. This propagates through and ensures `D` is never tiny and so `iD` never blows up without any additional thresholding. Of course `D=0` in the body, so `iD` is set to 0 there as well, completely deactivating those cells.

I was very surprised to see that the kernels are not type stable. So I fixed those too.

Here is an updated version of issue #137 :
```julia
using WaterLily,StaticArrays

function circle(center;ϵ=1,Re=100,n=3*2^6,m=2^7,U=1,T=typeof(center))
    radius = m÷8
    body = AutoBody((x,t)->√sum(abs2, x .- center) - radius)
    Simulation((n,m), (U,0), radius; ν=U*radius/Re, body,T,ϵ)
end
function circle_ke(x;kwargs...)
    sim = circle(x;kwargs...)
    sim_step!(sim)
    sum(I->WaterLily.ke(I,sim.flow.u,SA[1,0]),inside(sim.flow.p))
end

using Plots
begin
    x = range(64,66,200); x0 = x[1]
    Δ(f) = x->f(x)-f(x0)
    plot(x,Δ(x->circle_ke(Float64(x),ϵ=1)),label="Float64, ϵ=1",c=:blue)
    plot!(x,Δ(x->circle_ke(Float32(x),ϵ=1)),label="Float32, ϵ=1",ls=:dash,c=:lightblue)
    plot!(x,Δ(x->circle_ke(Float64(x),ϵ=2)),label="Float64, ϵ=2",c=:red)
    plot!(x,Δ(x->circle_ke(Float32(x),ϵ=2)),label="Float32, ϵ=2",ls=:dash,c=:orange)
end
```
Which now gives a smooth result for all four cases!
<img width="600" height="400" alt="plot_7" src="https://github.com/user-attachments/assets/6fffe484-5939-4c19-8160-8dce8e0ec954" />

