### PR TITLE
GPU-safe nested ForwardDiff AD in `measure`

### DIFF
--- a/src/AutoBody.jl
+++ b/src/AutoBody.jl
@@ -29,11 +29,11 @@ Skips the `n,V` calculation when `d²>fastd²`.
 function measure(body::AutoBody,x,t;fastd²=Inf)
     d = sdf(body,x,t)
     d^2>fastd² && return (d,zero(x),zero(x))
-    n = _grad(ξ->body.sdf(ξ,t), body.map(x,t)) # body-frame only
+    n = gradient(ξ->body.sdf(ξ,t), body.map(x,t)) # body-frame only
     any(isnan, n) && return (d,zero(x),zero(x)) # handle non-diff'able points
-    J = _jac(x->body.map(x,t), x)               # for mapping n,V to x-frame
-    n = J'n; m = √sum(abs2,n); d /= m; n /= m   # chain rule then normalise
-    return (d, n, -J\_derivative(t->body.map(x,t), t))
+    J = jacobian(x->body.map(x,t), x)             # for mapping n,V to x-frame
+    n = J'n; m = √sum(abs2,n); d /= m; n /= m     # chain rule then normalise
+    return (d, n, -J\derivative(t->body.map(x,t), t))
 end
 
 using LinearAlgebra: tr

--- a/src/AutoBody.jl
+++ b/src/AutoBody.jl
@@ -18,55 +18,6 @@ AutoBody(sdf, map=(x,t)->x) = AutoBody(sdf, map)
 """
 @inline sdf(body::AutoBody,x,t=0;kwargs...) = body.sdf(body.map(x,t),t)
 
-using ForwardDiff
-using ForwardDiff: Dual, partials, Tag
-
-# Inner-derivative tag for measure's gradient/jacobian/derivative on `body.sdf`
-# and `body.map`. Compile-time singleton: `≺` is overloaded so it always ranks
-# strictly newer than any outer `ForwardDiff.Tag`. This lets nested AD work on
-# the GPU — the stock ForwardDiff path goes through `extract_jacobian`/`valtype`,
-# which calls `tagcount` (a side-effecting generated function) at runtime; on
-# GPU the codegen can instantiate the inner tag's count before the host
-# instantiates the outer's, inverting the precedence and triggering
-# `DualMismatchError` inside the kernel.
-struct _InnerTag end
-@inline ForwardDiff.:≺(::Type{<:Tag}, ::Type{_InnerTag}) = true
-@inline ForwardDiff.:≺(::Type{_InnerTag}, ::Type{<:Tag}) = false
-@inline ForwardDiff.:≺(::Type{_InnerTag}, ::Type{_InnerTag}) = false
-
-# Tag-aware partial extractor: returns the i-th partial only if `y` carries an
-# `_InnerTag` dual; otherwise the function did not depend on the seeded input
-# and the inner derivative is exactly zero. Without this guard a non-_InnerTag
-# `y` (which could still be an outer-tag `Dual` pulled in by closure capture)
-# would silently return the outer partial.
-@inline _ip(y::Dual{_InnerTag}, i::Int) = partials(y, i)
-@inline _ip(y, ::Int) = zero(y)
-
-# Tag-stable, GPU-safe gradient/jacobian/derivative on SVector inputs. They
-# extract `partials` directly so neither `extract_jacobian` nor `valtype` is hit.
-@inline function _gradient(f::F, x::SVector{N,T}) where {F,N,T}
-    seeds = ntuple(i -> Dual{_InnerTag}(x[i], ntuple(j -> ifelse(j==i, one(T), zero(T)), Val(N))), Val(N))
-    y = f(SVector(seeds))
-    SVector(ntuple(j -> _ip(y, j), Val(N)))
-end
-@inline function _jacobian(f::F, x::SVector{N,T}) where {F,N,T}
-    seeds = ntuple(i -> Dual{_InnerTag}(x[i], ntuple(j -> ifelse(j==i, one(T), zero(T)), Val(N))), Val(N))
-    _stack_jac(f(SVector(seeds)), Val(N))
-end
-@inline function _stack_jac(ydual::SVector{M}, ::Val{N}) where {M,N}
-    SMatrix{M,N}(ntuple(k -> _ip(ydual[((k-1) % M) + 1], ((k-1) ÷ M) + 1), Val(M*N)))
-end
-@inline _derivative(f::F, t::T) where {F,T} = map(yi -> _ip(yi, 1), f(Dual{_InnerTag}(t, one(T))))
-
-# Dispatch wrappers: the SVector path is GPU-safe, but `measure` may also be
-# called with plain `AbstractVector` inputs (e.g. user-facing tests). For non-
-# SVector inputs we fall back to stock ForwardDiff — this slow path doesn't
-# enter GPU kernels so the nested-FD GPU bug doesn't apply.
-@inline _grad(f, x::SVector) = _gradient(f, x)
-@inline _grad(f, x) = ForwardDiff.gradient(f, x)
-@inline _jac(f, x::SVector) = _jacobian(f, x)
-@inline _jac(f, x) = ForwardDiff.jacobian(f, x)
-
 """
     d,n,V = measure(body::AutoBody,x,t;fastd²=Inf)
 

--- a/src/AutoBody.jl
+++ b/src/AutoBody.jl
@@ -19,6 +19,54 @@ AutoBody(sdf, map=(x,t)->x) = AutoBody(sdf, map)
 @inline sdf(body::AutoBody,x,t=0;kwargs...) = body.sdf(body.map(x,t),t)
 
 using ForwardDiff
+using ForwardDiff: Dual, partials, Tag
+
+# Inner-derivative tag for measure's gradient/jacobian/derivative on `body.sdf`
+# and `body.map`. Compile-time singleton: `≺` is overloaded so it always ranks
+# strictly newer than any outer `ForwardDiff.Tag`. This lets nested AD work on
+# the GPU — the stock ForwardDiff path goes through `extract_jacobian`/`valtype`,
+# which calls `tagcount` (a side-effecting generated function) at runtime; on
+# GPU the codegen can instantiate the inner tag's count before the host
+# instantiates the outer's, inverting the precedence and triggering
+# `DualMismatchError` inside the kernel.
+struct _InnerTag end
+@inline ForwardDiff.:≺(::Type{<:Tag}, ::Type{_InnerTag}) = true
+@inline ForwardDiff.:≺(::Type{_InnerTag}, ::Type{<:Tag}) = false
+@inline ForwardDiff.:≺(::Type{_InnerTag}, ::Type{_InnerTag}) = false
+
+# Tag-aware partial extractor: returns the i-th partial only if `y` carries an
+# `_InnerTag` dual; otherwise the function did not depend on the seeded input
+# and the inner derivative is exactly zero. Without this guard a non-_InnerTag
+# `y` (which could still be an outer-tag `Dual` pulled in by closure capture)
+# would silently return the outer partial.
+@inline _ip(y::Dual{_InnerTag}, i::Int) = partials(y, i)
+@inline _ip(y, ::Int) = zero(y)
+
+# Tag-stable, GPU-safe gradient/jacobian/derivative on SVector inputs. They
+# extract `partials` directly so neither `extract_jacobian` nor `valtype` is hit.
+@inline function _gradient(f::F, x::SVector{N,T}) where {F,N,T}
+    seeds = ntuple(i -> Dual{_InnerTag}(x[i], ntuple(j -> ifelse(j==i, one(T), zero(T)), Val(N))), Val(N))
+    y = f(SVector(seeds))
+    SVector(ntuple(j -> _ip(y, j), Val(N)))
+end
+@inline function _jacobian(f::F, x::SVector{N,T}) where {F,N,T}
+    seeds = ntuple(i -> Dual{_InnerTag}(x[i], ntuple(j -> ifelse(j==i, one(T), zero(T)), Val(N))), Val(N))
+    _stack_jac(f(SVector(seeds)), Val(N))
+end
+@inline function _stack_jac(ydual::SVector{M}, ::Val{N}) where {M,N}
+    SMatrix{M,N}(ntuple(k -> _ip(ydual[((k-1) % M) + 1], ((k-1) ÷ M) + 1), Val(M*N)))
+end
+@inline _derivative(f::F, t::T) where {F,T} = map(yi -> _ip(yi, 1), f(Dual{_InnerTag}(t, one(T))))
+
+# Dispatch wrappers: the SVector path is GPU-safe, but `measure` may also be
+# called with plain `AbstractVector` inputs (e.g. user-facing tests). For non-
+# SVector inputs we fall back to stock ForwardDiff — this slow path doesn't
+# enter GPU kernels so the nested-FD GPU bug doesn't apply.
+@inline _grad(f, x::SVector) = _gradient(f, x)
+@inline _grad(f, x) = ForwardDiff.gradient(f, x)
+@inline _jac(f, x::SVector) = _jacobian(f, x)
+@inline _jac(f, x) = ForwardDiff.jacobian(f, x)
+
 """
     d,n,V = measure(body::AutoBody,x,t;fastd²=Inf)
 
@@ -30,11 +78,11 @@ Skips the `n,V` calculation when `d²>fastd²`.
 function measure(body::AutoBody,x,t;fastd²=Inf)
     d = sdf(body,x,t)
     d^2>fastd² && return (d,zero(x),zero(x))
-    n = ForwardDiff.gradient(ξ->body.sdf(ξ,t), body.map(x,t)) # body-frame only
-    any(isnan, n) && return (d,zero(x),zero(x))               # handle non-diff'able points
-    J = ForwardDiff.jacobian(x->body.map(x,t), x)             # for mapping n,V to x-frame
-    n = J'n; m = √sum(abs2,n); d /= m; n /= m                 # chain rule then normalise
-    return (d, n, -J\ForwardDiff.derivative(t->body.map(x,t), t))
+    n = _grad(ξ->body.sdf(ξ,t), body.map(x,t)) # body-frame only
+    any(isnan, n) && return (d,zero(x),zero(x)) # handle non-diff'able points
+    J = _jac(x->body.map(x,t), x)               # for mapping n,V to x-frame
+    n = J'n; m = √sum(abs2,n); d /= m; n /= m   # chain rule then normalise
+    return (d, n, -J\_derivative(t->body.map(x,t), t))
 end
 
 using LinearAlgebra: tr

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -69,8 +69,8 @@ Accounts for applied and reference-frame acceleration using `rᵢ += g(i,x,t)+dU
 accelerate!(r,t,::Nothing,::Union{Nothing,Tuple}) = nothing
 accelerate!(r,t,f::Function) = @loop r[Ii] += f(last(Ii),loc(Ii,eltype(r)),t) over Ii ∈ CartesianIndices(r)
 accelerate!(r,t,g::Function,::Union{Nothing,Tuple}) = accelerate!(r,t,g)
-accelerate!(r,t,::Nothing,U::Function) = accelerate!(r,t,(i,x,t)->ForwardDiff.derivative(τ->U(i,x,τ),t))
-accelerate!(r,t,g::Function,U::Function) = accelerate!(r,t,(i,x,t)->g(i,x,t)+ForwardDiff.derivative(τ->U(i,x,τ),t))
+accelerate!(r,t,::Nothing,U::Function) = accelerate!(r,t,(i,x,t)->derivative(τ->U(i,x,τ),t))
+accelerate!(r,t,g::Function,U::Function) = accelerate!(r,t,(i,x,t)->g(i,x,t)+derivative(τ->U(i,x,τ),t))
 """
     Flow{D::Int, T::Float, Sf<:AbstractArray{T,D}, Vf<:AbstractArray{T,D+1}, Tf<:AbstractArray{T,D+2}}
 

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -6,7 +6,7 @@ module WaterLily
 using DocStringExtensions
 
 include("util.jl")
-export L₂,BC!,@inside,inside,δ,apply!,loc,@log,set_backend,backend
+export L₂,BC!,@inside,inside,δ,apply!,loc,@log,set_backend,backend,derivative,gradient,jacobian
 
 using Reexport
 @reexport using KernelAbstractions: @kernel,@index,get_backend

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -6,7 +6,7 @@ module WaterLily
 using DocStringExtensions
 
 include("util.jl")
-export L₂,BC!,@inside,inside,δ,apply!,loc,@log,set_backend,backend,derivative,gradient,jacobian
+export L₂,BC!,@inside,inside,δ,apply!,loc,@log,set_backend,backend
 
 using Reexport
 @reexport using KernelAbstractions: @kernel,@index,get_backend

--- a/src/util.jl
+++ b/src/util.jl
@@ -339,3 +339,44 @@ ic_function(uBC::Function) = (i,x)->uBC(i,x,0)
 ic_function(uBC::Tuple) = (i,x)->uBC[i]
 
 squeeze(a::AbstractArray) = dropdims(a, dims = tuple(findall(size(a) .== 1)...))
+
+using ForwardDiff
+using ForwardDiff: Dual, partials, Tag
+
+# Inner-derivative tag for measure's gradient/jacobian/derivative on `body.sdf`
+# and `body.map`. Compile-time singleton: `≺` is overloaded so it always ranks
+# strictly newer than any outer `ForwardDiff.Tag`. This lets nested AD work on
+# the GPU
+struct _InnerTag end
+@inline ForwardDiff.:≺(::Type{<:Tag}, ::Type{_InnerTag}) = true
+@inline ForwardDiff.:≺(::Type{_InnerTag}, ::Type{<:Tag}) = false
+@inline ForwardDiff.:≺(::Type{_InnerTag}, ::Type{_InnerTag}) = false
+
+# Tag-aware partial extractor: returns the i-th partial only if `y` carries an
+# `_InnerTag` dual
+@inline _ip(y::Dual{_InnerTag}, i::Int) = partials(y, i)
+@inline _ip(y, ::Int) = zero(y)
+
+# Tag-stable, GPU-safe gradient/jacobian/derivative on SVector inputs. They
+# extract `partials` directly so neither `extract_jacobian` nor `valtype` is hit.
+@inline function _gradient(f::F, x::SVector{N,T}) where {F,N,T}
+    seeds = ntuple(i -> Dual{_InnerTag}(x[i], ntuple(j -> ifelse(j==i, one(T), zero(T)), Val(N))), Val(N))
+    y = f(SVector(seeds))
+    SVector(ntuple(j -> _ip(y, j), Val(N)))
+end
+@inline function _jacobian(f::F, x::SVector{N,T}) where {F,N,T}
+    seeds = ntuple(i -> Dual{_InnerTag}(x[i], ntuple(j -> ifelse(j==i, one(T), zero(T)), Val(N))), Val(N))
+    _stack_jac(f(SVector(seeds)), Val(N))
+end
+@inline function _stack_jac(ydual::SVector{M}, ::Val{N}) where {M,N}
+    SMatrix{M,N}(ntuple(k -> _ip(ydual[((k-1) % M) + 1], ((k-1) ÷ M) + 1), Val(M*N)))
+end
+@inline _derivative(f::F, t::T) where {F,T} = map(yi -> _ip(yi, 1), f(Dual{_InnerTag}(t, one(T))))
+
+# Dispatch wrappers: the SVector path is GPU-safe, but `measure` may also be
+# called with plain `AbstractVector` inputs (e.g. user-facing tests). For non-
+# SVector inputs we fall back to stock ForwardDiff
+@inline _grad(f, x::SVector) = _gradient(f, x)
+@inline _grad(f, x) = ForwardDiff.gradient(f, x)
+@inline _jac(f, x::SVector) = _jacobian(f, x)
+@inline _jac(f, x) = ForwardDiff.jacobian(f, x)

--- a/src/util.jl
+++ b/src/util.jl
@@ -373,12 +373,12 @@ end
 @inline function _stack_jac(ydual::SVector{M}, ::Val{N}) where {M,N}
     SMatrix{M,N}(ntuple(k -> _ip(ydual[((k-1) % M) + 1], ((k-1) ÷ M) + 1), Val(M*N)))
 end
-@inline _derivative(f::F, t::T) where {F,T} = map(yi -> _ip(yi, 1), f(Dual{_InnerTag}(t, one(T))))
+@inline derivative(f::F, t::T) where {F,T} = map(yi -> _ip(yi, 1), f(Dual{_InnerTag}(t, one(T))))
 
 # Dispatch wrappers. Internal `measure` calls always pass SVector (from `loc`)
 # and take the GPU-safe path; user-facing callers may pass plain `AbstractVector`
 # (e.g. unit tests) and route to stock ForwardDiff — CPU-only, GPU bug N/A.
-@inline _grad(f, x::SVector) = _gradient(f, x)
-@inline _grad(f, x) = ForwardDiff.gradient(f, x)
-@inline _jac(f, x::SVector) = _jacobian(f, x)
-@inline _jac(f, x) = ForwardDiff.jacobian(f, x)
+@inline gradient(f, x::SVector) = _gradient(f, x)
+@inline gradient(f, x) = ForwardDiff.gradient(f, x)
+@inline jacobian(f, x::SVector) = _jacobian(f, x)
+@inline jacobian(f, x) = ForwardDiff.jacobian(f, x)

--- a/src/util.jl
+++ b/src/util.jl
@@ -343,22 +343,24 @@ squeeze(a::AbstractArray) = dropdims(a, dims = tuple(findall(size(a) .== 1)...))
 using ForwardDiff
 using ForwardDiff: Dual, partials, Tag
 
-# Inner-derivative tag for measure's gradient/jacobian/derivative on `body.sdf`
-# and `body.map`. Compile-time singleton: `≺` is overloaded so it always ranks
-# strictly newer than any outer `ForwardDiff.Tag`. This lets nested AD work on
-# the GPU
+# Inner-derivative tag for measure's gradient/jacobian/derivative. `≺` is
+# overloaded so it always ranks newer than any `ForwardDiff.Tag`, folding the
+# precedence comparison at compile time and sidestepping `tagcount` (order-
+# sensitive on GPU codegen, the original cause of nested-FD crashes in kernels).
 struct _InnerTag end
 @inline ForwardDiff.:≺(::Type{<:Tag}, ::Type{_InnerTag}) = true
 @inline ForwardDiff.:≺(::Type{_InnerTag}, ::Type{<:Tag}) = false
 @inline ForwardDiff.:≺(::Type{_InnerTag}, ::Type{_InnerTag}) = false
 
-# Tag-aware partial extractor: returns the i-th partial only if `y` carries an
-# `_InnerTag` dual
+# Tag-aware partial extractor. The fallback returns zero when `y` is not an
+# `_InnerTag` dual — `f` did not depend on the seeded input so the inner
+# derivative is exactly zero. Without it, an outer-tag `Dual` (from closure
+# capture) would silently leak its outer partial.
 @inline _ip(y::Dual{_InnerTag}, i::Int) = partials(y, i)
 @inline _ip(y, ::Int) = zero(y)
 
-# Tag-stable, GPU-safe gradient/jacobian/derivative on SVector inputs. They
-# extract `partials` directly so neither `extract_jacobian` nor `valtype` is hit.
+# GPU-safe gradient/jacobian/derivative on SVector inputs: seed `Dual{_InnerTag}`
+# and extract `partials` directly, bypassing `extract_jacobian`/`valtype`.
 @inline function _gradient(f::F, x::SVector{N,T}) where {F,N,T}
     seeds = ntuple(i -> Dual{_InnerTag}(x[i], ntuple(j -> ifelse(j==i, one(T), zero(T)), Val(N))), Val(N))
     y = f(SVector(seeds))
@@ -373,9 +375,9 @@ end
 end
 @inline _derivative(f::F, t::T) where {F,T} = map(yi -> _ip(yi, 1), f(Dual{_InnerTag}(t, one(T))))
 
-# Dispatch wrappers: the SVector path is GPU-safe, but `measure` may also be
-# called with plain `AbstractVector` inputs (e.g. user-facing tests). For non-
-# SVector inputs we fall back to stock ForwardDiff
+# Dispatch wrappers. Internal `measure` calls always pass SVector (from `loc`)
+# and take the GPU-safe path; user-facing callers may pass plain `AbstractVector`
+# (e.g. unit tests) and route to stock ForwardDiff — CPU-only, GPU bug N/A.
 @inline _grad(f, x::SVector) = _gradient(f, x)
 @inline _grad(f, x) = ForwardDiff.gradient(f, x)
 @inline _jac(f, x::SVector) = _jacobian(f, x)

--- a/src/util.jl
+++ b/src/util.jl
@@ -359,14 +359,16 @@ struct _InnerTag end
 @inline _ip(y::Dual{_InnerTag}, i::Int) = partials(y, i)
 @inline _ip(y, ::Int) = zero(y)
 
-# GPU-safe gradient/jacobian/derivative on SVector inputs: seed `Dual{_InnerTag}`
-# and extract `partials` directly, bypassing `extract_jacobian`/`valtype`.
-@inline function _gradient(f::F, x::SVector{N,T}) where {F,N,T}
+# GPU-safe gradient/jacobian/derivative: seed `Dual{_InnerTag}` and extract
+# `partials` directly, bypassing `extract_jacobian`/`valtype`. SVector inputs
+# take the GPU-safe path; other inputs (plain `AbstractVector`, e.g. unit tests)
+# dispatch to ForwardDiff (CPU-only)
+@inline function gradient(f::F, x::SVector{N,T}) where {F,N,T}
     seeds = ntuple(i -> Dual{_InnerTag}(x[i], ntuple(j -> ifelse(j==i, one(T), zero(T)), Val(N))), Val(N))
     y = f(SVector(seeds))
     SVector(ntuple(j -> _ip(y, j), Val(N)))
 end
-@inline function _jacobian(f::F, x::SVector{N,T}) where {F,N,T}
+@inline function jacobian(f::F, x::SVector{N,T}) where {F,N,T}
     seeds = ntuple(i -> Dual{_InnerTag}(x[i], ntuple(j -> ifelse(j==i, one(T), zero(T)), Val(N))), Val(N))
     _stack_jac(f(SVector(seeds)), Val(N))
 end
@@ -374,11 +376,5 @@ end
     SMatrix{M,N}(ntuple(k -> _ip(ydual[((k-1) % M) + 1], ((k-1) ÷ M) + 1), Val(M*N)))
 end
 @inline derivative(f::F, t::T) where {F,T} = map(yi -> _ip(yi, 1), f(Dual{_InnerTag}(t, one(T))))
-
-# Dispatch wrappers. Internal `measure` calls always pass SVector (from `loc`)
-# and take the GPU-safe path; user-facing callers may pass plain `AbstractVector`
-# (e.g. unit tests) and route to stock ForwardDiff — CPU-only, GPU bug N/A.
-@inline gradient(f, x::SVector) = _gradient(f, x)
 @inline gradient(f, x) = ForwardDiff.gradient(f, x)
-@inline jacobian(f, x::SVector) = _jacobian(f, x)
 @inline jacobian(f, x) = ForwardDiff.jacobian(f, x)

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -344,14 +344,14 @@ end
     sdfn(ξ) = √sum(abs2, ξ) - 1
     rotmap(x, θ) = SA[cos(θ) -sin(θ); sin(θ) cos(θ)] * x
     x0 = SVector(0.5, 0.7); θ0 = 0.3
-    @test WaterLily._gradient(sdfn, x0) ≈ ForwardDiff.gradient(sdfn, x0)
-    @test WaterLily._jacobian(y -> rotmap(y, θ0), x0) ≈ ForwardDiff.jacobian(y -> rotmap(y, θ0), x0)
-    @test WaterLily._derivative(t -> rotmap(x0, t), θ0) ≈ ForwardDiff.derivative(t -> rotmap(x0, t), θ0)
+    @test gradient(sdfn, x0) ≈ ForwardDiff.gradient(sdfn, x0)
+    @test jacobian(y -> rotmap(y, θ0), x0) ≈ ForwardDiff.jacobian(y -> rotmap(y, θ0), x0)
+    @test derivative(t -> rotmap(x0, t), θ0) ≈ ForwardDiff.derivative(t -> rotmap(x0, t), θ0)
     let outer_tag = typeof(ForwardDiff.Tag(identity, Float64)),
         θd = Dual{outer_tag}(θ0, 1.0),
         ref = ForwardDiff.derivative(t -> sum(ForwardDiff.jacobian(y -> rotmap(y, t), x0)), θ0)
-        @test ForwardDiff.partials(sum(WaterLily._jacobian(y -> rotmap(y, θd), x0)), 1) ≈ ref
-    end
+        @test ForwardDiff.partials(sum(jacobian(y -> rotmap(y, θd), x0)), 1) ≈ ref
+            end
 
     # Tight kernel-level reproducer of the original GPU bug: call AutoBody.measure
     # inside a @kernel under outer Dual eltype. Without the fix, AutoBody.measure

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -353,6 +353,23 @@ end
         @test ForwardDiff.partials(sum(WaterLily._jacobian(y -> rotmap(y, θd), x0)), 1) ≈ ref
     end
 
+    # Tight kernel-level reproducer of the original GPU bug: call AutoBody.measure
+    # inside a @kernel under outer Dual eltype. Without the fix, AutoBody.measure
+    # uses stock ForwardDiff.jacobian → extract_jacobian → valtype → DualMismatchError
+    # inside the kernel and crashes with KernelException. The body is a line segment
+    # (not rotationally symmetric), so the integrated normal genuinely depends on θ.
+    function measure_sum(θ, mem; L=16)
+        body = AutoBody((ξ, _) -> √sum(abs2, ξ - SA[0, clamp(ξ[1], -L/2, L/2)]) - 2,
+                        (x, _) -> SA[cos(θ) -sin(θ); sin(θ) cos(θ)] * (x - SA[L, L]))
+        out = mem(zeros(typeof(θ), 2L, 2L))
+        WaterLily.@loop out[I] = WaterLily.measure(body, WaterLily.loc(0, I, typeof(θ)), zero(typeof(θ)))[2][1] over I ∈ CartesianIndices(out)
+        sum(out)
+    end
+    cpu_kd = derivative(t -> measure_sum(t, Array), 0.3)
+    for f ∈ arrays
+        @test derivative(t -> measure_sum(t, f), 0.3) ≈ cpu_kd rtol=1e-3
+    end
+
     # End-to-end: ∂/∂θ of sum(sim.flow.p) for a θ-rotated body, on each backend.
     # This can raise KernelException inside @kernel when `mem=CuArray` without tag reordering
     function rot_sim(θ, mem; L=32, U=1, Re=100)

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -97,7 +97,7 @@ backend != "KernelAbstractions" && throw(ArgumentError("SIMD backend not allowed
 
         # test on perdot
         σ1 = rand(Ng...) |> f # scalar
-        σ2 = rand(Ng...) |> f # another scalar 
+        σ2 = rand(Ng...) |> f # another scalar
         # use ≈ instead of == as summation in different order might result in slight difference in floating point expressions
         @test GPUArrays.@allowscalar WaterLily.perdot(σ1,σ2,())    ≈ sum(σ1[I]*σ2[I] for I∈CartesianIndices(σ1))
         @test GPUArrays.@allowscalar WaterLily.perdot(σ1,σ2,(1,))  ≈ sum(σ1[I]*σ2[I] for I∈inside(σ1))
@@ -332,6 +332,40 @@ end
     end
     h = 1e-6
     @test derivative(lift,2.0) ≈ (lift(2+h)-lift(2-h))/2h rtol=√h
+end
+
+@testset "AutoBody nested ForwardDiff (GPU-safe)" begin
+    using ForwardDiff
+    using ForwardDiff: derivative, Dual
+    # Bypass extract_jacobian/valtype in ForwardDiff.jl so nested FD
+    # works inside GPU kernels. Sanity-check that they match stock ForwardDiff,
+    # both with a plain Float input and with an outer-Dual eltype (the nested
+    # case that actually crashed extract_jacobian on GPU codegen).
+    sdfn(ξ) = √sum(abs2, ξ) - 1
+    rotmap(x, θ) = SA[cos(θ) -sin(θ); sin(θ) cos(θ)] * x
+    x0 = SVector(0.5, 0.7); θ0 = 0.3
+    @test WaterLily._gradient(sdfn, x0) ≈ ForwardDiff.gradient(sdfn, x0)
+    @test WaterLily._jacobian(y -> rotmap(y, θ0), x0) ≈ ForwardDiff.jacobian(y -> rotmap(y, θ0), x0)
+    @test WaterLily._derivative(t -> rotmap(x0, t), θ0) ≈ ForwardDiff.derivative(t -> rotmap(x0, t), θ0)
+    let outer_tag = typeof(ForwardDiff.Tag(identity, Float64)),
+        θd = Dual{outer_tag}(θ0, 1.0),
+        ref = ForwardDiff.derivative(t -> sum(ForwardDiff.jacobian(y -> rotmap(y, t), x0)), θ0)
+        @test ForwardDiff.partials(sum(WaterLily._jacobian(y -> rotmap(y, θd), x0)), 1) ≈ ref
+    end
+
+    # End-to-end: ∂/∂θ of sum(sim.flow.p) for a θ-rotated body, on each backend.
+    # This can raise KernelException inside @kernel when `mem=CuArray` without tag reordering
+    function rot_sim(θ, mem; L=32, U=1, Re=100)
+        s, c = sincos(θ)
+        body = AutoBody((ξ, _) -> √sum(abs2, ξ - SA[0, clamp(ξ[1], -L/2, L/2)]) - 2,
+                        (x, _) -> SA[c -s; s c] * (x - SA[L, L]))
+        Simulation((2L, 2L), (U, 0), L; ν=U*L/Re, body, T=typeof(θ), mem)
+    end
+    dsim(θ, mem) = (sim = rot_sim(θ, mem); sim_step!(sim); sum(sim.flow.p))
+    cpu_d = derivative(t -> dsim(t, Array), Float64(π/36))
+    for f ∈ arrays
+        @test derivative(t -> dsim(t, f), Float64(π/36)) ≈ cpu_d rtol=1e-3
+    end
 end
 
 function acceleratingFlow(N;use_g=false,T=Float64,perdir=(1,),jerk=4,mem=Array)

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -344,13 +344,13 @@ end
     sdfn(ξ) = √sum(abs2, ξ) - 1
     rotmap(x, θ) = SA[cos(θ) -sin(θ); sin(θ) cos(θ)] * x
     x0 = SVector(0.5, 0.7); θ0 = 0.3
-    @test gradient(sdfn, x0) ≈ ForwardDiff.gradient(sdfn, x0)
-    @test jacobian(y -> rotmap(y, θ0), x0) ≈ ForwardDiff.jacobian(y -> rotmap(y, θ0), x0)
-    @test derivative(t -> rotmap(x0, t), θ0) ≈ ForwardDiff.derivative(t -> rotmap(x0, t), θ0)
+    @test WaterLily.gradient(sdfn, x0) ≈ ForwardDiff.gradient(sdfn, x0)
+    @test WaterLily.jacobian(y -> rotmap(y, θ0), x0) ≈ ForwardDiff.jacobian(y -> rotmap(y, θ0), x0)
+    @test WaterLily.derivative(t -> rotmap(x0, t), θ0) ≈ ForwardDiff.derivative(t -> rotmap(x0, t), θ0)
     let outer_tag = typeof(ForwardDiff.Tag(identity, Float64)),
         θd = Dual{outer_tag}(θ0, 1.0),
         ref = ForwardDiff.derivative(t -> sum(ForwardDiff.jacobian(y -> rotmap(y, t), x0)), θ0)
-        @test ForwardDiff.partials(sum(jacobian(y -> rotmap(y, θd), x0)), 1) ≈ ref
+        @test ForwardDiff.partials(sum(WaterLily.jacobian(y -> rotmap(y, θd), x0)), 1) ≈ ref
             end
 
     # Tight kernel-level reproducer of the original GPU bug: call AutoBody.measure

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -308,35 +308,9 @@ end
               WaterLily.L₂(u[:,:,2].-ue[:,:,2]) < 1e-4
     end
 end
+
 @testset "ForwardDiff" begin
-    function TGV_ke(Re)
-        sim,_ = TGVsim(Array;Re)
-        sim_step!(sim,π/100)
-        sum(I->WaterLily.ke(I,sim.flow.u),inside(sim.flow.p))
-    end
-    using ForwardDiff:derivative
-    @test derivative(TGV_ke,1e2) ≈ (TGV_ke(1e2+1)-TGV_ke(1e2-1))/2 rtol=1e-1
-
-    # Spinning cylinder lift generation
-    rot(θ) = SA[cos(θ) -sin(θ); sin(θ) cos(θ)]  # rotation matrix
-    function spinning(ξ;D=16,Re=500)
-        C,R,U = SA[D,D],D÷2,1
-        body = AutoBody((x,t)->√(x'*x)-R,          # circle sdf
-                        (x,t)->rot(ξ*U*t/R)*(x-C)) # center & spin!
-        Simulation((2D,2D),(U,0),D;ν=U*D/Re,body,T=typeof(ξ))
-    end
-    function lift(ξ,t_end=1)
-        sim = spinning(ξ)
-        sim_step!(sim,t_end;remeasure=false)
-        WaterLily.total_force(sim)[2]/(ξ^2*sim.U^2*sim.L)
-    end
-    h = 1e-6
-    @test derivative(lift,2.0) ≈ (lift(2+h)-lift(2-h))/2h rtol=√h
-end
-
-@testset "AutoBody nested ForwardDiff (GPU-safe)" begin
     using ForwardDiff
-    using ForwardDiff: derivative, Dual
     # Bypass extract_jacobian/valtype in ForwardDiff.jl so nested FD
     # works inside GPU kernels. Sanity-check that they match stock ForwardDiff,
     # both with a plain Float input and with an outer-Dual eltype (the nested
@@ -348,7 +322,7 @@ end
     @test WaterLily.jacobian(y -> rotmap(y, θ0), x0) ≈ ForwardDiff.jacobian(y -> rotmap(y, θ0), x0)
     @test WaterLily.derivative(t -> rotmap(x0, t), θ0) ≈ ForwardDiff.derivative(t -> rotmap(x0, t), θ0)
     let outer_tag = typeof(ForwardDiff.Tag(identity, Float64)),
-        θd = Dual{outer_tag}(θ0, 1.0),
+        θd = ForwardDiff.Dual{outer_tag}(θ0, 1.0),
         ref = ForwardDiff.derivative(t -> sum(ForwardDiff.jacobian(y -> rotmap(y, t), x0)), θ0)
         @test ForwardDiff.partials(sum(WaterLily.jacobian(y -> rotmap(y, θd), x0)), 1) ≈ ref
             end
@@ -365,23 +339,53 @@ end
         WaterLily.@loop out[I] = WaterLily.measure(body, WaterLily.loc(0, I, typeof(θ)), zero(typeof(θ)))[2][1] over I ∈ CartesianIndices(out)
         sum(out)
     end
-    cpu_kd = derivative(t -> measure_sum(t, Array), 0.3)
+    cpu_kd = ForwardDiff.derivative(t -> measure_sum(t, Array), 0.3)
     for f ∈ arrays
-        @test derivative(t -> measure_sum(t, f), 0.3) ≈ cpu_kd rtol=1e-3
+        @test ForwardDiff.derivative(t -> measure_sum(t, f), 0.3) ≈ cpu_kd rtol=1e-3
     end
 
-    # End-to-end: ∂/∂θ of sum(sim.flow.p) for a θ-rotated body, on each backend.
-    # This can raise KernelException inside @kernel when `mem=CuArray` without tag reordering
-    function rot_sim(θ, mem; L=32, U=1, Re=100)
+    # End-to-end ForwardDiff AD
+    # ∂/∂Re of KE for TGV
+    function tgv_sim(Re, mem)
+        sim,_ = TGVsim(mem; Re)
+        sim_step!(sim,π/100)
+        WaterLily.@loop sim.flow.σ[I] = WaterLily.ke(I, sim.flow.u) over I ∈ inside(sim.flow.p)
+        sum(@view sim.flow.σ[inside(sim.flow.p)])
+    end
+    # ∂/∂Lift of spinning cylinder lift generation
+    rot(θ) = SA[cos(θ) -sin(θ); sin(θ) cos(θ)]  # rotation matrix
+    function spinning(ξ, mem; D=16, Re=500)
+        C,R,U = SA[D,D],D÷2,1
+        body = AutoBody((x,t)->√(x'*x)-R,          # circle sdf
+                        (x,t)->rot(ξ*U*t/R)*(x-C)) # center & spin!
+        Simulation((2D,2D), (U,0), D; ν=U*D/Re, body, mem, T=typeof(ξ))
+    end
+    function spin_sim(ξ, mem)
+        sim = spinning(ξ, mem)
+        sim_step!(sim, 1; remeasure=false)
+        WaterLily.total_force(sim)[2]/(ξ^2*sim.U^2*sim.L)
+    end
+    # ∂/∂θ of sum(sim.flow.p) for a θ-rotated body
+    function rotating(θ, mem; L=32, U=1, Re=100)
         s, c = sincos(θ)
         body = AutoBody((ξ, _) -> √sum(abs2, ξ - SA[0, clamp(ξ[1], -L/2, L/2)]) - 2,
                         (x, _) -> SA[c -s; s c] * (x - SA[L, L]))
         Simulation((2L, 2L), (U, 0), L; ν=U*L/Re, body, T=typeof(θ), mem)
     end
-    dsim(θ, mem) = (sim = rot_sim(θ, mem); sim_step!(sim); sum(sim.flow.p))
-    cpu_d = derivative(t -> dsim(t, Array), Float64(π/36))
+    rot_sim(θ, mem) = (sim = rotating(θ, mem); sim_step!(sim; max_steps=10); sum(sim.flow.p))
+
+    # Compare derivative between FD, AD_CPU and AD_GPU
+    h = 1
+    dtgv_fd = (tgv_sim(1e2+h, Array) - tgv_sim(1e2-h, Array)) / 2h
+    h = 1e-6
+    dspin_fd = (spin_sim(2+h, Array) - spin_sim(2-h, Array)) / 2h
+    h = π/36/100
+    drot_fd = (rot_sim(π/36+h, Array) - rot_sim(π/36-h, Array)) / 2h
+
     for f ∈ arrays
-        @test derivative(t -> dsim(t, f), Float64(π/36)) ≈ cpu_d rtol=1e-3
+        @test ForwardDiff.derivative(x -> tgv_sim(x, f), 1e2) ≈ dtgv_fd rtol=1e-1
+        @test ForwardDiff.derivative(x -> spin_sim(x, f), 2f0) ≈ dspin_fd rtol=√1e-6
+        @test ForwardDiff.derivative(x -> rot_sim(x, f), π/36) ≈ drot_fd rtol=1e-3
     end
 end
 


### PR DESCRIPTION
### Claude-assisted PR to fix ForwardDiff.jl on GPU backends

## Problem

Forward AD via ForwardDiff.jl failed on GPU. For example

```julia
ForwardDiff.derivative(t -> sim_step!(Simulation(...; mem=CuArray); ...), θ₀)
```
failed at runtime inside the GPU kernel:
```sh
KernelException: a exception was thrown during kernel execution
  ...
  valtype at ForwardDiff/.../dual.jl:137
  extract_jacobian at ForwardDiffStaticArraysExt.jl:80
  measure at WaterLily/src/AutoBody.jl:35
```

## Root cause

`AutoBody.measure` calls `ForwardDiff.gradient/jacobian/derivative` on the user's `sdf`/`map`. When the *outer* `derivative` over θ wraps these calls, ForwardDiff's `extract_jacobian` invokes `valtype(T_inner, Dual{T_outer,V,N})`, which falls into a fallback that compares tag precedence via `≺`, which calls `tagcount` — a `@generated` function with side-effecting state. On GPU, codegen can instantiate the inner-tag's count *before* the host instantiates the outer-tag's, inverting precedence and triggering `DualMismatchError` inside the kernel.

## Fix

In `src/util.jl`:

- Custom singleton tag `_InnerTag` for measure's inner derivatives, with `≺` overloaded so it always ranks statically newer than any `ForwardDiff.Tag`. The comparison folds at compile time and never touches `tagcount`.
- Helpers `_gradient` / `_jacobian` / `_derivative` for SVector inputs that seed `Dual{_InnerTag}` and extract `partials` directly — bypassing `extract_jacobian` / `extract_gradient` / `valtype` entirely.
- Tag-aware `_ip(y, i)` extractor: returns the i-th partial only if `y` carries an `_InnerTag` dual, else `zero(y)`. Required because if the user's function ignores the seeded input (e.g. `body.map` test bodies that don't depend on `t`), `f(seed)` returns the outer dual unchanged and `partials(yi, i)` would otherwise return the wrong (outer) partial.
- Dispatch wrappers `_grad`, `_jac` fall back to stock `ForwardDiff` for non-SVector inputs (user-facing API tests still pass plain `Vector`s; that path is CPU-only and the GPU bug doesn't apply).

In `src/AutoBody.jl`: `measure` now calls `_grad` / `_jac` / `_derivative` instead of stock `ForwardDiff`. No other changes.

## Verification

<details>
<summary>ad_test.jl</summary>

```julia
using WaterLily
using StaticArrays
using ForwardDiff
using CUDA

function make_sim(θ; L=32, U=1, Re=100, mem=Array)
    function map(x, _)
        s, c = sincos(θ)
        SA[c -s; s c] * (x - SA[L, L])
    end
    function sdf(ξ, _)
        p = ξ - SA[0, clamp(ξ[1], -L / 2, L / 2)]
        √(p' * p) - 2
    end
    Simulation((2L, 2L), (U, 0), L, ν=U * L / Re, body=AutoBody(sdf, map), T=typeof(θ), mem=mem)
end

function dsim_CPU(θ)
    sim = make_sim(θ)
    sim_step!(sim)
    sum(sim.flow.p)
end
function dsim_GPU(θ)
    sim = make_sim(θ; mem=CuArray)
    sim_step!(sim)
    sum(sim.flow.p)
end

function main()
    θ = Float64(π / 36)
    @info ForwardDiff.derivative(dsim_CPU, θ) # 5.632740043288322
    @info ForwardDiff.derivative(dsim_GPU, θ) # 5.632740043463173
end

main()
```

</details>

  - ForwardDiff CPU: `5.632740043288322` (matches master baseline exactly).
  - ForwardDiff GPU: `5.632740043463173` (matches CPU to 9 sig figs — **new**).
- Full WaterLily test suite passes on `Array` + `CuArray` backends.

## Tests added

New testset `"AutoBody nested ForwardDiff (GPU-safe)"` in `test/maintests.jl`, **8 tests**, runs across all backends in `arrays`:

1. `_gradient` / `_jacobian` / `_derivative` numerically match stock `ForwardDiff` for `SVector` inputs.
2. `_jacobian` under an outer `ForwardDiff.Tag`-tagged `Dual` matches the nested reference.
3. **Kernel-level regression test**: calls `measure` inside `WaterLily.@loop` with an outer-Dual θ closure; on master without the fix this raises `KernelException` on `CuArray`. With the fix both backends produce `-3.5480099515290675`.
4. **End-to-end**: `∂/∂θ` of `sum(sim.flow.p)` for a θ-rotated body, run on each backend.

## Commits

```
e6ca730 AutoBody: GPU-safe nested ForwardDiff in measure
e291923 Moved ForwardDiff.jl helper functions into utils.jl and trimmed docs
53fd468 test: add nested-ForwardDiff regression tests for AutoBody.measure
774f904 test: add kernel-level reproducer for the original GPU bug
```

## Known related issue (out of scope)

`viscous_force` / `total_force` under outer-Dual on GPU crashes with `CUDA error: an illegal memory access`. **Pre-existing on master** — not introduced by this PR. `--check-bounds=yes` makes it work and produces correct values, so an `@inbounds` access in the chain produces an OOB index that the CPU silently tolerates but CUDA traps. Suspected register-pressure / codegen interaction in the `SMatrix×SVector` with both operands being nested-Dual; each operand in isolation works. Should be filed upstream against CUDA.jl/GPUCompiler with a minimal repro.
