### PR TITLE
Refactor Flow and introduce AbstractFlow type to improve specialization

### DIFF
--- a/ext/WaterLilyJLD2Ext.jl
+++ b/ext/WaterLilyJLD2Ext.jl
@@ -4,11 +4,11 @@ using JLD2, WaterLily
 import WaterLily: save!, load!
 
 """
-    save!(fname, flow::Flow; dir="./")
+    save!(fname, flow::AbstractFlow; dir="./")
 
-Save the `flow::Flow` pressure, velocity, and time steps arrays into a JLD2-formatted binary file (HDF5 compatible).
+Save the `flow::AbstractFlow` pressure, velocity, and time steps arrays into a JLD2-formatted binary file (HDF5 compatible).
 """
-save!(fname, flow::Flow; dir="./") = jldsave(
+save!(fname, flow::AbstractFlow; dir="./") = jldsave(
     joinpath(dir, fname);
     p=Array(flow.p),
     u=Array(flow.u),
@@ -30,12 +30,12 @@ save!(fname, meanflow::MeanFlow; dir="./") = jldsave(
 )
 
 """
-    load!(flow::Flow; kwargs...)
+    load!(flow::AbstractFlow; kwargs...)
 
 Load pressure, velocity, and time steps arrays from a JLD2-formatted binary file.
 Keyword arguments considered are `fname="WaterLily.jld2"` and `dir="./"`.
 """
-function load!(flow::Flow; kwargs...)
+function load!(flow::AbstractFlow; kwargs...)
     fname = get(Dict(kwargs), :fname, "WaterLily.jld2")
     dir = get(Dict(kwargs), :dir, "./")
     obj = jldopen(joinpath(dir, fname))

--- a/src/Body.jl
+++ b/src/Body.jl
@@ -12,7 +12,7 @@ A fast-approximate method can return `≈d,zero(x),zero(x)` if `d^2>fastd²`.
 """
 abstract type AbstractBody end
 """
-    measure!(flow::Flow, body::AbstractBody; t=0, ϵ=1)
+    measure!(flow::AbstractFlow, body::AbstractBody; t=0, ϵ=1)
 
 Queries the body geometry to fill the arrays:
 
@@ -25,7 +25,7 @@ of size `2+ϵ` around the body. This function also fills `flow.σ` with the sign
 
 See Maertens & Weymouth, doi:[10.1016/j.cma.2014.09.007](https://doi.org/10.1016/j.cma.2014.09.007).
 """
-function measure!(a::Flow{N,T},body::AbstractBody;t=zero(T),ϵ=1) where {N,T}
+function measure!(a::AbstractFlow{N,T},body::AbstractBody;t=zero(T),ϵ=1) where {N,T}
     a.V .= zero(T); a.μ₀ .= one(T); a.μ₁ .= zero(T); d²=T(2+ϵ)^2
     measure_sdf!(a.σ, body, t; fastd²=d²) # measure separately to allow specialization
     @fastmath @inline function fill!(μ₀,μ₁,V,d,I)
@@ -80,7 +80,7 @@ Use for a simulation without a body.
 """
 struct NoBody <: AbstractBody end
 measure(::NoBody,x::AbstractVector,args...;kwargs...)=(Inf,zero(x),zero(x))
-function measure!(::Flow,::NoBody;kwargs...) end # skip measure! entirely
+function measure!(::AbstractFlow,::NoBody;kwargs...) end # skip measure! entirely
 
 """
     SetBody

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -71,6 +71,8 @@ accelerate!(r,t,f::Function) = @loop r[Ii] += f(last(Ii),loc(Ii,eltype(r)),t) ov
 accelerate!(r,t,g::Function,::Union{Nothing,Tuple}) = accelerate!(r,t,g)
 accelerate!(r,t,::Nothing,U::Function) = accelerate!(r,t,(i,x,t)->ForwardDiff.derivative(τ->U(i,x,τ),t))
 accelerate!(r,t,g::Function,U::Function) = accelerate!(r,t,(i,x,t)->g(i,x,t)+ForwardDiff.derivative(τ->U(i,x,τ),t))
+
+abstract type AbstractFlow end
 """
     Flow{D::Int, T::Float, Sf<:AbstractArray{T,D}, Vf<:AbstractArray{T,D+1}, Tf<:AbstractArray{T,D+2}}
 
@@ -81,7 +83,7 @@ Solid boundaries are modelled using the [Boundary Data Immersion Method](https:/
 The primary variables are the scalar pressure `p` (an array of dimension `D`)
 and the velocity vector field `u` (an array of dimension `D+1`).
 """
-struct Flow{D, T, Sf<:AbstractArray{T}, Vf<:AbstractArray{T}, Tf<:AbstractArray{T}}
+struct Flow{D, T, Sf<:AbstractArray{T}, Vf<:AbstractArray{T}, Tf<:AbstractArray{T}} <: AbstractFlow
     # Fluid fields
     u :: Vf # velocity vector field
     u⁰:: Vf # previous velocity
@@ -116,54 +118,85 @@ struct Flow{D, T, Sf<:AbstractArray{T}, Vf<:AbstractArray{T}, Tf<:AbstractArray{
 end
 
 """
+    mom_step!(a::AbstractFlow,b::AbstractPoisson;λ=quick,udf=nothing,kwargs...)
+
+Integrate the `Flow` one time step using the [Boundary Data Immersion Method](https://eprints.soton.ac.uk/369635/)
+and the `AbstractPoisson` pressure solver to project the velocity onto an incompressible flow.
+"""
+@fastmath function mom_step!(a::AbstractFlow,b::AbstractPoisson;λ=quick,udf=nothing,kwargs...)
+    a.u⁰ .= a.u; scale_u!(a,0); t₁ = sum(a.Δt); t₀ = t₁-a.Δt[end]
+    # predictor u → u'
+    @log "p"
+    mom_predict!(a,t₀,t₁;λ,udf,kwargs...)
+    mom_project!(a,b,1,t₁)
+    # corrector u → u¹
+    @log "c"
+    mom_correct!(a,t₁;λ,udf,kwargs...)
+    mom_project!(a,b,0.5,t₁)
+    push!(a.Δt,CFL(a))
+end
+
+"""
     time(a::Flow)
 
 Current flow time.
 """
-time(a::Flow) = sum(@view(a.Δt[1:end-1]))
+time(a::AbstractFlow) = sum(@view(a.Δt[1:end-1]))
 
-function BDIM!(a::Flow)
+function BDIM!(a::AbstractFlow)
     dt = a.Δt[end]
     @loop a.f[Ii] = a.u⁰[Ii]+dt*a.f[Ii]-a.V[Ii] over Ii in CartesianIndices(a.f)
     @loop a.u[Ii] += μddn(Ii,a.μ₁,a.f)+a.V[Ii]+a.μ₀[Ii]*a.f[Ii] over Ii ∈ inside_u(size(a.p))
 end
 
-function project!(a::Flow{n},b::AbstractPoisson,w=1) where n
-    dt = w*a.Δt[end]
-    @inside b.z[I] = div(I,a.u); b.x .*= dt # set source term & solution IC
-    solver!(b)
-    for i ∈ 1:n  # apply solution and unscale to recover pressure
-        @loop a.u[I,i] -= b.L[I,i]*∂(i,I,b.x) over I ∈ inside(b.x)
-    end
-    b.x ./= dt
-end
-
 """
-    mom_step!(a::Flow,b::AbstractPoisson;λ=quick,udf=nothing,kwargs...)
+    mom_predict!(a::AbstractFlow, t; λ=quick, udf=nothing, kwargs...)
 
-Integrate the `Flow` one time step using the [Boundary Data Immersion Method](https://eprints.soton.ac.uk/369635/)
-and the `AbstractPoisson` pressure solver to project the velocity onto an incompressible flow.
+Predictor phase of `mom_step!`: advect under `u⁰`, apply BDIM, enforce BCs.
+On return `a.u` is BC-consistent and ready for pressure projection.
+`t` is the start-of-step time used for forcing terms; BCs are enforced at the
+end-of-step time `sum(a.Δt)`.
 """
-@fastmath function mom_step!(a::Flow{N},b::AbstractPoisson;λ=quick,udf=nothing,kwargs...) where N
-    a.u⁰ .= a.u; scale_u!(a,0); t₁ = sum(a.Δt); t₀ = t₁-a.Δt[end]
-    # predictor u → u'
-    @log "p"
+function mom_predict!(a::AbstractFlow, t₀, t₁; λ=quick, udf=nothing, kwargs...)
     conv_diff!(a.f,a.u⁰,a.σ,λ;ν=a.ν,perdir=a.perdir)
     udf!(a,udf,t₀; kwargs...)
     accelerate!(a.f,t₀,a.g,a.uBC)
     BDIM!(a); BC!(a.u,a.uBC,a.exitBC,a.perdir,t₁) # BC MUST be at t₁
     a.exitBC && exitBC!(a.u,a.u⁰,a.Δt[end]) # convective exit
-    project!(a,b); BC!(a.u,a.uBC,a.exitBC,a.perdir,t₁)
-    # corrector u → u¹
-    @log "c"
+end
+
+"""
+    mom_correct!(a::AbstractFlow, t; λ=quick, udf=nothing, kwargs...)
+
+Corrector phase of `mom_step!`: advect under the projected `u`, apply BDIM,
+blend with the trapezoidal weight, enforce BCs.
+On return `a.u` is BC-consistent and ready for pressure projection.
+"""
+function mom_correct!(a::AbstractFlow, t; λ=quick, udf=nothing, kwargs...)
     conv_diff!(a.f,a.u,a.σ,λ;ν=a.ν,perdir=a.perdir)
-    udf!(a,udf,t₁; kwargs...)
-    accelerate!(a.f,t₁,a.g,a.uBC)
-    BDIM!(a); scale_u!(a,0.5); BC!(a.u,a.uBC,a.exitBC,a.perdir,t₁)
-    project!(a,b,0.5); BC!(a.u,a.uBC,a.exitBC,a.perdir,t₁)
-    push!(a.Δt,CFL(a))
+    udf!(a,udf,t; kwargs...)
+    accelerate!(a.f,t,a.g,a.uBC)
+    BDIM!(a); scale_u!(a,0.5); BC!(a.u,a.uBC,a.exitBC,a.perdir,t)
 end
 scale_u!(a,scale) = @loop a.u[Ii] *= scale over Ii ∈ inside_u(size(a.p))
+
+"""
+    mom_project!(a::AbstractFlow, b::AbstractPoisson, w, t)
+
+Projection phase of `mom_step!`: solve the pressure Poisson equation, correct
+the velocity by `w·Δt·∇p`, and re-enforce BCs.
+On return `a.u` is divergence-free and BC-consistent.
+"""
+function mom_project!(a::AbstractFlow, b::AbstractPoisson, w, t)
+    dt = w*a.Δt[end]
+    @inside b.z[I] = div(I,a.u); b.x .*= dt # set source term & solution IC
+    solver!(b)
+    for i ∈ 1:ndims(a.p)  # apply solution and unscale to recover pressure
+        @loop a.u[I,i] -= b.L[I,i]*∂(i,I,b.x) over I ∈ inside(b.x)
+    end
+    b.x ./= dt
+    BC!(a.u,a.uBC,a.exitBC,a.perdir,t)
+end
 
 function CFL(a::Flow;Δt_max=10)
     @inside a.σ[I] = flux_out(I,a.u)

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -72,7 +72,7 @@ accelerate!(r,t,g::Function,::Union{Nothing,Tuple}) = accelerate!(r,t,g)
 accelerate!(r,t,::Nothing,U::Function) = accelerate!(r,t,(i,x,t)->ForwardDiff.derivative(τ->U(i,x,τ),t))
 accelerate!(r,t,g::Function,U::Function) = accelerate!(r,t,(i,x,t)->g(i,x,t)+ForwardDiff.derivative(τ->U(i,x,τ),t))
 
-abstract type AbstractFlow end
+abstract type AbstractFlow{D,T} end
 """
     Flow{D::Int, T::Float, Sf<:AbstractArray{T,D}, Vf<:AbstractArray{T,D+1}, Tf<:AbstractArray{T,D+2}}
 
@@ -83,7 +83,7 @@ Solid boundaries are modelled using the [Boundary Data Immersion Method](https:/
 The primary variables are the scalar pressure `p` (an array of dimension `D`)
 and the velocity vector field `u` (an array of dimension `D+1`).
 """
-struct Flow{D, T, Sf<:AbstractArray{T}, Vf<:AbstractArray{T}, Tf<:AbstractArray{T}} <: AbstractFlow
+struct Flow{D, T, Sf<:AbstractArray{T}, Vf<:AbstractArray{T}, Tf<:AbstractArray{T}} <: AbstractFlow{D,T}
     # Fluid fields
     u :: Vf # velocity vector field
     u⁰:: Vf # previous velocity
@@ -137,7 +137,7 @@ and the `AbstractPoisson` pressure solver to project the velocity onto an incomp
 end
 
 """
-    time(a::Flow)
+    time(a::AbstractFlow)
 
 Current flow time.
 """
@@ -198,7 +198,7 @@ function mom_project!(a::AbstractFlow, b::AbstractPoisson, w, t)
     BC!(a.u,a.uBC,a.exitBC,a.perdir,t)
 end
 
-function CFL(a::Flow;Δt_max=10)
+function CFL(a::AbstractFlow;Δt_max=10)
     @inside a.σ[I] = flux_out(I,a.u)
     min(Δt_max,inv(maximum(a.σ)+5a.ν))
 end
@@ -211,9 +211,9 @@ end
 end
 
 """
-    udf!(flow::Flow,udf::Function,t)
+    udf!(flow::AbstractFlow,udf::Function,t)
 
-User defined function using `udf::Function` to operate on `flow::Flow` during the predictor and corrector step, in sync with time `t`.
+User defined function using `udf::Function` to operate on `flow::AbstractFlow` during the predictor and corrector step, in sync with time `t`.
 Keyword arguments must be passed to `sim_step!` for them to be carried over the actual function call.
 """
 udf!(flow,::Nothing,t; kwargs...) = nothing

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -101,17 +101,17 @@ struct Flow{D, T, Sf<:AbstractArray{T}, Vf<:AbstractArray{T}, Tf<:AbstractArray{
     g :: Union{Function,Nothing} # acceleration field funciton
     exitBC :: Bool # Convection exit
     perdir :: NTuple # tuple of periodic direction
-    function Flow(N::NTuple{D}, uBC; f=Array, Δt=0.25, ν=0., g=nothing,
+    function Flow(N::NTuple{D}, uBC; mem=Array, Δt=0.25, ν=0., g=nothing,
             uλ=nothing, perdir=(), exitBC=false, T=Float32) where D
         Ng = N .+ 2
         Nd = (Ng..., D)
         isnothing(uλ) && (uλ = ic_function(uBC))
-        u = Array{T}(undef, Nd...) |> f
+        u = Array{T}(undef, Nd...) |> mem
         isa(uλ, Function) ? apply!(uλ, u) : apply!((i,x)->uλ[i], u)
         BC!(u,uBC,exitBC,perdir); exitBC!(u,u,0.)
         u⁰ = copy(u)
-        fv, p, σ = zeros(T, Nd) |> f, zeros(T, Ng) |> f, zeros(T, Ng) |> f
-        V, μ₀, μ₁ = zeros(T, Nd) |> f, ones(T, Nd) |> f, zeros(T, Ng..., D, D) |> f
+        fv, p, σ = zeros(T, Nd) |> mem, zeros(T, Ng) |> mem, zeros(T, Ng) |> mem
+        V, μ₀, μ₁ = zeros(T, Nd) |> mem, ones(T, Nd) |> mem, zeros(T, Ng..., D, D) |> mem
         BC!(μ₀,ntuple(zero, D),false,perdir)
         new{D,T,typeof(p),typeof(u),typeof(μ₁)}(u,u⁰,fv,p,σ,V,μ₀,μ₁,uBC,T[Δt],T(ν),g,exitBC,perdir)
     end
@@ -150,11 +150,11 @@ function BDIM!(a::AbstractFlow)
 end
 
 """
-    mom_predict!(a::AbstractFlow, t; λ=quick, udf=nothing, kwargs...)
+    mom_predict!(a::AbstractFlow, t₀, t₁; λ=quick, udf=nothing, kwargs...)
 
 Predictor phase of `mom_step!`: advect under `u⁰`, apply BDIM, enforce BCs.
 On return `a.u` is BC-consistent and ready for pressure projection.
-`t` is the start-of-step time used for forcing terms; BCs are enforced at the
+`t₀` and `t₁` are the start and end times of the step; BCs are enforced at the
 end-of-step time `sum(a.Δt)`.
 """
 function mom_predict!(a::AbstractFlow, t₀, t₁; λ=quick, udf=nothing, kwargs...)
@@ -169,7 +169,7 @@ end
     mom_correct!(a::AbstractFlow, t; λ=quick, udf=nothing, kwargs...)
 
 Corrector phase of `mom_step!`: advect under the projected `u`, apply BDIM,
-blend with the trapezoidal weight, enforce BCs.
+blend with the trapezoidal weight, enforce BCs at time-step end-time `t`.
 On return `a.u` is BC-consistent and ready for pressure projection.
 """
 function mom_correct!(a::AbstractFlow, t; λ=quick, udf=nothing, kwargs...)

--- a/src/Metrics.jl
+++ b/src/Metrics.jl
@@ -162,7 +162,7 @@ struct MeanFlow{T, Sf<:AbstractArray{T}, Vf<:AbstractArray{T}, Mf}
     UU :: Mf # squared-velocity tensor, u⊗u
     t :: Vector{T} # time steps vector
     uu_stats :: Bool # flag to compute UU on-the-fly temporal averages
-    function MeanFlow(flow::Flow{D,T}; t_init=time(flow), uu_stats=false) where {D,T}
+    function MeanFlow(flow::AbstractFlow{D,T}; t_init=time(flow), uu_stats=false) where {D,T}
         mem = typeof(flow.u).name.wrapper
         P = zeros(T, size(flow.p)) |> mem
         U = zeros(T, size(flow.u)) |> mem
@@ -187,7 +187,7 @@ function reset!(meanflow::MeanFlow; t_init=0.0)
     push!(meanflow.t, t_init)
 end
 
-function update!(meanflow::MeanFlow, flow::Flow)
+function update!(meanflow::MeanFlow, flow::AbstractFlow)
     dt = time(flow) - meanflow.t[end]
     ε = dt / (dt + time(meanflow) + eps(eltype(flow.p)))
     length(meanflow.t) == 1 && (ε = 1) # if it's the first update, we just take the instantaneous flow field
@@ -210,7 +210,7 @@ function uu(a::MeanFlow)
     return τ
 end
 
-function copy!(a::Flow, b::MeanFlow)
+function copy!(a::AbstractFlow, b::MeanFlow)
     a.u .= b.U
     a.p .= b.P
 end

--- a/src/Poisson.jl
+++ b/src/Poisson.jl
@@ -1,4 +1,5 @@
 abstract type AbstractPoisson{T,S,V} end
+update!(::AbstractPoisson) = nothing
 
 """
     Poisson{N,M}

--- a/src/Poisson.jl
+++ b/src/Poisson.jl
@@ -1,5 +1,4 @@
 abstract type AbstractPoisson{T,S,V} end
-update!(::AbstractPoisson) = nothing
 
 """
     Poisson{N,M}

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -18,7 +18,7 @@ include("MultiLevelPoisson.jl")
 export MultiLevelPoisson,solver!,mult!
 
 include("Flow.jl")
-export Flow,mom_step!,quick,cds
+export AbstractFlow,Flow,mom_step!,quick,cds
 
 include("Body.jl")
 export AbstractBody,measure_sdf!

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -66,19 +66,21 @@ mutable struct Simulation <: AbstractSimulation
     U :: Number # velocity scale
     L :: Number # length scale
     ϵ :: Number # kernel width
-    flow :: Flow
+    flow :: AbstractFlow
     body :: AbstractBody
     pois :: AbstractPoisson
     function Simulation(dims::NTuple{N}, uBC, L::Number;
                         Δt=0.25, ν=0., g=nothing, U=nothing, ϵ=1, perdir=(),
                         uλ=nothing, exitBC=false, body::AbstractBody=NoBody(),
+                        flow_ctor=(dims,uBC;kw...)->Flow(dims,uBC;kw...),
+                        pois_ctor=flow->MultiLevelPoisson(flow.p,flow.μ₀,flow.σ;perdir),
                         T=Float32, mem=Array) where N
         @assert !(isnothing(U) && isa(uBC,Function)) "`U` (velocity scale) must be specified if boundary conditions `uBC` is a `Function`"
         isnothing(U) && (U = √sum(abs2,uBC))
         check_fn(uBC,N,T,3); check_fn(g,N,T,3); check_fn(uλ,N,T,2)
-        flow = Flow(dims,uBC;uλ,Δt,ν,g,T,f=mem,perdir,exitBC)
+        flow = flow_ctor(dims,uBC;uλ,Δt,ν,g,T,f=mem,perdir,exitBC)
         measure!(flow,body;ϵ)
-        new(U,L,ϵ,flow,body,MultiLevelPoisson(flow.p,flow.μ₀,flow.σ;perdir))
+        new(U,L,ϵ,flow,body,pois_ctor(flow))
     end
 end
 

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -86,7 +86,7 @@ mutable struct Simulation <: AbstractSimulation
         @assert !(isnothing(U) && isa(uBC,Function)) "`U` (velocity scale) must be specified if boundary conditions `uBC` is a `Function`"
         isnothing(U) && (U = √sum(abs2,uBC))
         check_fn(uBC,N,T,3); check_fn(g,N,T,3); check_fn(uλ,N,T,2)
-        flow = flow_ctor(dims,uBC;uλ,Δt,ν,g,T,f=mem,perdir,exitBC)
+        flow = flow_ctor(dims,uBC;uλ,Δt,ν,g,T,mem,perdir,exitBC)
         measure!(flow,body;ϵ)
         new(U,L,ϵ,flow,body,pois_ctor(flow))
     end

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -108,7 +108,7 @@ sim_time(sim::AbstractSimulation) = time(sim)*sim.U/sim.L
 
 Integrate the simulation `sim` up to dimensionless time `t_end`.
 If `remeasure=true`, the body is remeasured at every time step. Can be set to `false` for static geometries to speed up simulation.
-A user-defined function `udf` can be passed to arbitrarily modify the `::Flow` during the predictor and corrector steps.
+A user-defined function `udf` can be passed to arbitrarily modify the `::AbstractFlow` during the predictor and corrector steps.
 If the `udf` user keyword arguments, these needs to be included in the `sim_step!` call as well.
 A `λ::Function` function can be passed as a custom convective scheme, following the interface of `λ(u,c,d)` (for upstream, central,
 downstream points).

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -39,7 +39,9 @@ export RigidMap,setmap
                U=norm2(Uλ), Δt=0.25, ν=0., ϵ=1, g=nothing,
                perdir=(), exitBC=false,
                body::AbstractBody=NoBody(),
-               T=Float32, mem=Array)
+               T=Float32, mem=Array,
+               flow_ctor=(dims,uBC;kw...)->Flow(dims,uBC;kw...),
+               pois_ctor=flow->MultiLevelPoisson(flow.p,flow.μ₀,flow.σ;perdir))
 
 Constructor for a WaterLily.jl simulation:
 
@@ -59,6 +61,12 @@ Constructor for a WaterLily.jl simulation:
   - `body`: Immersed geometry.
   - `T`: Array element type.
   - `mem`: memory location. `Array`, `CuArray`, `ROCm` to run on CPU, NVIDIA, or AMD devices, respectively.
+  - `flow_ctor`: Factory callable `(dims, uBC; kw...) -> AbstractFlow` to substitute a custom flow type.
+        The callable receives all standard keyword arguments forwarded from this constructor.
+        Used by downstream packages (e.g. LilyPad.jl) to inject a custom `AbstractFlow` subtype.
+  - `pois_ctor`: Factory callable `flow -> AbstractPoisson` to substitute a custom Poisson solver.
+        Called after `flow_ctor` with the constructed flow as argument.
+        Used by downstream packages (e.g. BiotSavartBCs.jl) to inject a custom `AbstractPoisson` subtype.
 
 See files in `examples` folder for examples.
 """

--- a/test/alloctest.jl
+++ b/test/alloctest.jl
@@ -38,4 +38,18 @@ backend != "SIMD" && throw(ArgumentError("KernelAbstractions backend not allowed
     r = run(b)
     println("▶ Allocated "*@sprintf("%.0f", r.memory/1e3)*" KiB")
     @test r.memory < 50000 # less than 50 KiB allocated on the best mom_step! run (commit f721343 ≈ 8 KiB)
+
+    # Verify AbstractFlow type widening did not introduce allocations via dynamic dispatch
+    # flow_ctor produces a Flow <: AbstractFlow; mom_step! must still be fully compiled
+    let θ=Float32(π/36), L=32, U=1, Re=100
+        function map2(x,t); s,c=sincos(θ); SA[c -s;s c]*(x-SA[L,L]) end
+        function sdf2(ξ,t); p=ξ-SA[0,clamp(ξ[1],-L/2,L/2)]; √(p'*p)-2 end
+        sim2 = Simulation((20L,20L),(U,0),L;ν=U*L/Re,body=AutoBody(sdf2,map2),T=Float32,
+                          flow_ctor=(d,u;kw...)->Flow(d,u;kw...))
+        sim_step!(sim2)
+        b = @benchmarkable mom_step!($sim2.flow, $sim2.pois) samples=100; tune!(b)
+        r = run(b)
+        println("▶ Allocated (flow_ctor path) "*@sprintf("%.0f", r.memory/1e3)*" KiB")
+        @test r.memory < 50000 # AbstractFlow dispatch must not allocate more than concrete Flow
+    end
 end

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -348,7 +348,7 @@ function acceleratingFlow(N;use_g=false,T=Float64,perdir=(1,),jerk=4,mem=Array)
         (N,N), (UScale,0.), N; ν=0.001,g,Δt=0.001,perdir,T,mem
     ),jerk
 end
-gravity!(flow::Flow,t; jerk=4) = for i ∈ 1:last(size(flow.f))
+gravity!(flow::AbstractFlow,t; jerk=4) = for i ∈ 1:last(size(flow.f))
     WaterLily.@loop flow.f[I,i] += i==1 ? t*jerk : 0 over I ∈ CartesianIndices(Base.front(size(flow.f)))
 end
 @testset "Flow.jl with increasing body force" begin
@@ -395,7 +395,7 @@ end
         coriolis(i,x,t) = i==1 ? 2ω*velocity(2,x,t) : -2ω*velocity(1,x,t)
         centrifugal(i,x,t) = ω^2*(x-x₀)[i]
         g(i,x,t) = coriolis(i,x,t)+centrifugal(i,x,t)
-        udf(a::Flow,t) = WaterLily.@loop a.f[Ii] += g(last(Ii),loc(Ii,eltype(a.f)),t) over Ii in CartesianIndices(a.f)
+        udf(a::AbstractFlow,t) = WaterLily.@loop a.f[Ii] += g(last(Ii),loc(Ii,eltype(a.f)),t) over Ii in CartesianIndices(a.f)
         simg = Simulation((N,N),velocity,N; g, U=1, T, mem) # use g
         simg,Simulation((N,N),velocity,N; U=1, T, mem),udf
     end

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -228,8 +228,8 @@ end
     # Impulsive flow in a box
     U = (2/3, -1/3)
     N = (2^4, 2^4)
-    for f ∈ arrays
-        a = Flow(N, U; f, T=Float32)
+    for mem ∈ arrays
+        a = Flow(N, U; mem, T=Float32)
         mom_step!(a, MultiLevelPoisson(a.p,a.μ₀,a.σ))
         @test L₂(a.u[:,:,1].-U[1]) < 2e-5
         @test L₂(a.u[:,:,2].-U[2]) < 1e-5
@@ -544,6 +544,19 @@ end
         @test length(sim.pois.n)==2 && all(sim.pois.n .<5)
         @test 1.2 > sim.flow.Δt[end] > 0.8
     end
+    # Test flow_ctor factory: explicit lambda wrapping Flow produces a working simulation
+    sim = Simulation(nm,(1,0),radius; body=AutoBody(circle), ν, T,
+                     flow_ctor=(d,u;kw...)->Flow(d,u;kw...))
+    @test sim.flow isa Flow
+    sim_step!(sim,0.5,remeasure=false)
+    @test all(isfinite, sim.flow.u)
+
+    # Test pois_ctor factory: explicit lambda wrapping MultiLevelPoisson produces a working simulation
+    sim = Simulation(nm,(1,0),radius; body=AutoBody(circle), ν, T,
+                     pois_ctor=flow->MultiLevelPoisson(flow.p,flow.μ₀,flow.σ))
+    @test sim.pois isa MultiLevelPoisson
+    sim_step!(sim,0.5,remeasure=false)
+    @test all(isfinite, sim.flow.u)
 end
 
 function sphere_sim(radius = 8; D=2, mem=Array, exitBC=false)


### PR DESCRIPTION

### Problem
`mom_step!` is a monolithic orchestrator. Downstream packages that need to specialise one phase (e.g. BiotSavartBCs replacing the pressure projection, LilyPad replacing advection) must copy the entire function and maintain it in sync with upstream. This is the only current extension point.

### Strategy
**Template Method pattern**: Add `AbstractFlow` type and decompose `mom_step!` into high-level functions which can be type-specialized:
- `mom_predict!` / `mom_correct!` dispatch on `AbstractFlow`.
- `mom_project!` dispatches on `(AbstractFlow, AbstractPoisson)` — the Poisson type carries the solver strategy. BiotSavart state (`ω`, `tar`, `x₀`) should migrate into a `BiotSavartPoisson <: AbstractPoisson`, not a wrapper simulation type.

### BC invariant
BCs are **part of the phase that produces the field they close**, not a separate post-processing step. The justification is mathematical: a divergence-free field that violates the domain BC is not a valid solenoidal field. Callers may rely on each phase returning a BC-consistent velocity.