### PR TITLE
Add scalar conservative transport! helper

### DIFF
--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -62,6 +62,66 @@ lowerBoundary!(r,u,Φ,ν,i,j,N,λ,::Val{true}) = @loop (
 upperBoundary!(r,u,Φ,ν,i,j,N,λ,::Val{true}) = @loop r[I-δ(j,I),i] -= Φ[CIj(j,I,2)] over I ∈ slice(N,N[j],j,2)
 
 """
+    transport!(r, φ, u, Φ; D_diff=0, λ=quick, perdir=())
+
+Scalar conservative advection–diffusion residual. Computes
+
+```
+r[I] = -∂_j (u_j φ - D_diff ∂_j φ)
+```
+
+in cell-centered form using the same QUICK/CDS/vanLeer machinery as
+`conv_diff!`. `r` and `φ` are `D`-dimensional cell-centered arrays (size
+matching `Flow.p`); `u` is the WaterLily staggered velocity array
+(`size(u) == (size(φ)..., D)`); `Φ` is a workspace buffer of the same
+shape as `φ` (e.g. `Flow.σ`). `D_diff` is the (scalar) diffusivity.
+
+Intended as a building block for VoF α-advection, scalar RANS
+transport, or passive tracers.
+"""
+function transport!(r::AbstractArray{T,Dim},
+                    φ::AbstractArray{T,Dim},
+                    u::AbstractArray{T},
+                    Φ::AbstractArray{T,Dim};
+                    D_diff=zero(T), λ=quick, perdir=()) where {T,Dim}
+    @assert ndims(u) == Dim + 1 "u must have ndims(φ)+1 dimensions"
+    r .= zero(T)
+    N = size(φ)
+    for j in 1:Dim
+        tagper = j in perdir
+        scalar_lowerBoundary!(r, φ, u, Φ, D_diff, j, N, λ, Val{tagper}())
+        @loop (Φ[I] = ϕu(j,I,φ,u[CI(I,j)],λ) - D_diff*∂(j,I,φ);
+               r[I] += Φ[I]) over I ∈ inside_scalar_j(N, j)
+        @loop r[I-δ(j,I)] -= Φ[I] over I ∈ inside_scalar_j(N, j)
+        scalar_upperBoundary!(r, φ, u, Φ, D_diff, j, N, λ, Val{tagper}())
+    end
+    return r
+end
+
+# Interior indices for the scalar transport flux loop in direction j:
+# all cells whose `j` coordinate is in 3:N[j]-1 — the same buffer the
+# QUICK stencil needs (-2δ to +δ in direction j).
+@inline inside_scalar_j(N::NTuple{D}, j) where D =
+    CartesianIndices(ntuple(k -> k == j ? (3:N[k]-1) : (2:N[k]-1), D))
+
+# Boundary slice for the scalar transport kernel. Matches `slice` along
+# the active axis but iterates only the *interior* orthogonal indices
+# 2:N[k]-1, so the boundary kernel never writes to orthogonal ghost
+# cells.
+@inline scalar_slice(N::NTuple{D}, i, j) where D =
+    CartesianIndices(ntuple(k -> k == j ? (i:i) : (2:N[k]-1), D))
+
+# Neumann (zero-gradient) scalar boundaries: drop the upstream stencil
+# point and use ϕuL/ϕuR.
+scalar_lowerBoundary!(r,φ,u,Φ,D_diff,j,N,λ,::Val{false}) = @loop r[I] += ϕuL(j,I,φ,u[CI(I,j)],λ) - D_diff*∂(j,I,φ) over I ∈ scalar_slice(N, 2, j)
+scalar_upperBoundary!(r,φ,u,Φ,D_diff,j,N,λ,::Val{false}) = @loop r[I-δ(j,I)] += -ϕuR(j,I,φ,u[CI(I,j)],λ) + D_diff*∂(j,I,φ) over I ∈ scalar_slice(N, N[j], j)
+
+# Periodic scalar boundaries.
+scalar_lowerBoundary!(r,φ,u,Φ,D_diff,j,N,λ,::Val{true}) = @loop (
+    Φ[I] = ϕuP(j,CIj(j,I,N[j]-2),I,φ,u[CI(I,j)],λ) - D_diff*∂(j,I,φ); r[I] += Φ[I]) over I ∈ scalar_slice(N, 2, j)
+scalar_upperBoundary!(r,φ,u,Φ,D_diff,j,N,λ,::Val{true}) = @loop r[I-δ(j,I)] -= Φ[CIj(j,I,2)] over I ∈ scalar_slice(N, N[j], j)
+
+"""
     accelerate!(r,t,g,U)
 
 Accounts for applied and reference-frame acceleration using `rᵢ += g(i,x,t)+dU(i,x,t)/dt`

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -74,11 +74,19 @@ in cell-centered form using the same QUICK/CDS/vanLeer machinery as
 `conv_diff!`. `r` and `φ` are `D`-dimensional cell-centered arrays (size
 matching `Flow.p`); `u` is the WaterLily staggered velocity array
 (`size(u) == (size(φ)..., D)`); `Φ` is a workspace buffer of the same
-shape as `φ` (e.g. `Flow.σ`). `D_diff` is the (scalar) diffusivity.
+shape as `φ` (e.g. `Flow.σ`). `D_diff` is the scalar diffusivity: a
+`Number` (uniform), a cell-centred `AbstractArray` matching `φ`, or a
+callable `D(I)` — all face-averaged.
 
 Intended as a building block for VoF α-advection, scalar RANS
 transport, or passive tracers.
 """
+# Face diffusivity for transport!: a Number is uniform, an array is read
+# per cell and averaged to the face, a callable is evaluated on the fly.
+@inline _Df(D::Number,j,I) = D
+@inline _Df(D::AbstractArray,j,I) = @inbounds (D[I] + D[I-δ(j,I)]) / 2
+@inline _Df(D,j,I) = @inbounds (D(I) + D(I-δ(j,I))) / 2
+
 function transport!(r::AbstractArray{T,Dim},
                     φ::AbstractArray{T,Dim},
                     u::AbstractArray{T},
@@ -90,7 +98,7 @@ function transport!(r::AbstractArray{T,Dim},
     for j in 1:Dim
         tagper = j in perdir
         scalar_lowerBoundary!(r, φ, u, Φ, D_diff, j, N, λ, Val{tagper}())
-        @loop (Φ[I] = ϕu(j,I,φ,u[CI(I,j)],λ) - D_diff*∂(j,I,φ);
+        @loop (Φ[I] = ϕu(j,I,φ,u[CI(I,j)],λ) - _Df(D_diff,j,I)*∂(j,I,φ);
                r[I] += Φ[I]) over I ∈ inside_scalar_j(N, j)
         @loop r[I-δ(j,I)] -= Φ[I] over I ∈ inside_scalar_j(N, j)
         scalar_upperBoundary!(r, φ, u, Φ, D_diff, j, N, λ, Val{tagper}())
@@ -113,12 +121,12 @@ end
 
 # Neumann (zero-gradient) scalar boundaries: drop the upstream stencil
 # point and use ϕuL/ϕuR.
-scalar_lowerBoundary!(r,φ,u,Φ,D_diff,j,N,λ,::Val{false}) = @loop r[I] += ϕuL(j,I,φ,u[CI(I,j)],λ) - D_diff*∂(j,I,φ) over I ∈ scalar_slice(N, 2, j)
-scalar_upperBoundary!(r,φ,u,Φ,D_diff,j,N,λ,::Val{false}) = @loop r[I-δ(j,I)] += -ϕuR(j,I,φ,u[CI(I,j)],λ) + D_diff*∂(j,I,φ) over I ∈ scalar_slice(N, N[j], j)
+scalar_lowerBoundary!(r,φ,u,Φ,D_diff,j,N,λ,::Val{false}) = @loop r[I] += ϕuL(j,I,φ,u[CI(I,j)],λ) - _Df(D_diff,j,I)*∂(j,I,φ) over I ∈ scalar_slice(N, 2, j)
+scalar_upperBoundary!(r,φ,u,Φ,D_diff,j,N,λ,::Val{false}) = @loop r[I-δ(j,I)] += -ϕuR(j,I,φ,u[CI(I,j)],λ) + _Df(D_diff,j,I)*∂(j,I,φ) over I ∈ scalar_slice(N, N[j], j)
 
 # Periodic scalar boundaries.
 scalar_lowerBoundary!(r,φ,u,Φ,D_diff,j,N,λ,::Val{true}) = @loop (
-    Φ[I] = ϕuP(j,CIj(j,I,N[j]-2),I,φ,u[CI(I,j)],λ) - D_diff*∂(j,I,φ); r[I] += Φ[I]) over I ∈ scalar_slice(N, 2, j)
+    Φ[I] = ϕuP(j,CIj(j,I,N[j]-2),I,φ,u[CI(I,j)],λ) - _Df(D_diff,j,I)*∂(j,I,φ); r[I] += Φ[I]) over I ∈ scalar_slice(N, 2, j)
 scalar_upperBoundary!(r,φ,u,Φ,D_diff,j,N,λ,::Val{true}) = @loop r[I-δ(j,I)] -= Φ[CIj(j,I,2)] over I ∈ scalar_slice(N, N[j], j)
 
 """

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -18,7 +18,7 @@ include("MultiLevelPoisson.jl")
 export MultiLevelPoisson,solver!,mult!
 
 include("Flow.jl")
-export AbstractFlow,Flow,mom_step!,quick,cds
+export AbstractFlow,Flow,mom_step!,quick,vanLeer,cds,transport!
 
 include("Body.jl")
 export AbstractBody,measure_sdf!

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -236,6 +236,33 @@ end
     end
 end
 
+@testset "transport! does not pollute orthogonal ghost cells" begin
+    # scalar_*Boundary! used to iterate orthogonal indices `2:N[k]`
+    # (= slice with low=2) and write `r[I]` / `r[I-δ]` at I[k]=N[k] —
+    # the upper-k ghost row. The fixed range is `2:N[k]-1` and ghost
+    # rows stay zero.
+    N = (16, 16)
+    φ = zeros(Float32, N .+ 2 ...)
+    u = zeros(Float32, (N .+ 2)..., 2)
+    Φ = zeros(Float32, N .+ 2 ...)
+    r = zeros(Float32, N .+ 2 ...)
+    # Seed the field with arbitrary non-uniform values so the kernel
+    # produces non-trivial fluxes.
+    for I in CartesianIndices(φ)
+        φ[I] = sin(I[1] / 4) + cos(I[2] / 4)
+    end
+    u[:, :, 1] .= 1.0
+    WaterLily.transport!(r, φ, u, Φ)
+    # Ghost rows along the y-orthogonal direction (k=2) should be
+    # untouched, i.e. still zero (not written into).
+    @test all(iszero, r[:, 1])
+    @test all(iszero, r[:, end])
+    @test all(iszero, r[1, :])
+    @test all(iszero, r[end, :])
+end
+
+include("transport_test.jl")
+
 @testset "Body.jl" begin
     @test WaterLily.μ₀(3.,6)==WaterLily.μ₀(0.5,1)
     @test WaterLily.μ₀(0.,1)==0.5

--- a/test/transport_test.jl
+++ b/test/transport_test.jl
@@ -88,4 +88,30 @@ using StaticArrays
         @test sum(@view φ_new[17:20, 8]) > sum(@view φ[17:20, 8])
     end
 
+    @testset "diffusivity field: array/closure match the scalar" begin
+        # D_diff may be a Number, a cell-centred array, or a callable; a
+        # constant array/closure must reproduce the scalar-D result, and a
+        # varying field must change it.
+        N = (16, 16); Ng = N .+ 2
+        φ = zeros(Float32, Ng)
+        for I in CartesianIndices(φ)
+            φ[I] = Float32((I.I[1] - 1.5)^2)
+        end
+        u = zeros(Float32, (Ng..., 2))
+        D = 0.1f0
+        rs = similar(φ); Φs = similar(φ)
+        ra = similar(φ); Φa = similar(φ)
+        rc = similar(φ); Φc = similar(φ)
+        Darr = fill(D, Ng)
+        WaterLily.transport!(rs, φ, u, Φs; D_diff=D)
+        WaterLily.transport!(ra, φ, u, Φa; D_diff=Darr)
+        WaterLily.transport!(rc, φ, u, Φc; D_diff=(I -> @inbounds Darr[I]))
+        @test maximum(abs.(rs .- ra)) ≤ 4 * eps(Float32) * maximum(abs.(rs))
+        @test maximum(abs.(rs .- rc)) ≤ 4 * eps(Float32) * maximum(abs.(rs))
+        Dvar = copy(Darr); Dvar[8:end, :] .= 0.5f0
+        rv = similar(φ); Φv = similar(φ)
+        WaterLily.transport!(rv, φ, u, Φv; D_diff=Dvar)
+        @test maximum(abs.(rv .- rs)) > 0
+    end
+
 end

--- a/test/transport_test.jl
+++ b/test/transport_test.jl
@@ -1,0 +1,91 @@
+# Regression test for the scalar transport! helper.
+#
+# transport!(r, φ, u, Φ; D_diff, λ, perdir) computes the cell-centred
+# conservative advection-diffusion residual for a passive scalar.
+
+using Test
+using WaterLily
+using StaticArrays
+
+@testset "transport!" begin
+
+    @testset "uniform advection conserves total mass" begin
+        # 2D: a smooth blob in a uniform stream. ∑ φ should not change
+        # under transport! (the residual integrates to zero up to BC
+        # fluxes, which for a blob in the interior is exactly zero).
+        N = (32, 32)
+        Ng = N .+ 2
+        φ = zeros(Float32, Ng)
+        # Gaussian blob centred at (16, 16) with std=3
+        for I in CartesianIndices(φ)
+            x, y = I.I .- 1.5
+            φ[I] = exp(-((x-16)^2 + (y-16)^2) / 9)
+        end
+        # Uniform stream in +x: u_x = 1, u_y = 0, on the staggered grid
+        u = zeros(Float32, (Ng..., 2))
+        u[:, :, 1] .= 1f0   # x-velocity
+
+        r = similar(φ); Φ = similar(φ)
+        WaterLily.transport!(r, φ, u, Φ; D_diff=0f0)
+
+        # Sum of residual over the interior should be the net flux through
+        # all interior faces — which sums to zero for a closed interior.
+        # (For a Gaussian centred well away from any boundary, this is
+        # zero in exact arithmetic; allow Float32 rounding.)
+        mass_change = sum(@view r[2:end-1, 2:end-1])
+        @test abs(mass_change) < 1e-4
+    end
+
+    @testset "still fluid → no transport" begin
+        N = (16, 16)
+        Ng = N .+ 2
+        φ = rand(Float32, Ng)
+        u = zeros(Float32, (Ng..., 2))   # u = 0
+        r = similar(φ); Φ = similar(φ)
+        WaterLily.transport!(r, φ, u, Φ; D_diff=0f0)
+        # No flux anywhere → r should be exactly zero
+        @test all(iszero, r)
+    end
+
+    @testset "pure diffusion: r matches D·∇²φ on interior" begin
+        # With u=0, transport! reduces to D · Laplacian(φ).
+        N = (16, 16)
+        Ng = N .+ 2
+        φ = zeros(Float32, Ng)
+        # Quadratic profile: φ = x²; ∇²φ = 2 → r = -∂_j(-D ∂_j φ) = D · 2
+        # Wait — transport! computes r = -∂_j(uⱼφ - D ∂_j φ). With u=0:
+        # r = -∂_j(-D ∂_j φ) = D · ∂_j ∂_j φ = D · ∇²φ. Sign: positive
+        # diffusion lowers high points, so r at the peak should be negative.
+        # For φ = x² with D > 0, ∇²φ = 2 (constant), so r = 2D everywhere.
+        for I in CartesianIndices(φ)
+            x = I.I[1] - 1.5
+            φ[I] = Float32(x^2)
+        end
+        u = zeros(Float32, (Ng..., 2))
+        D = 0.1f0
+        r = similar(φ); Φ = similar(φ)
+        WaterLily.transport!(r, φ, u, Φ; D_diff=D)
+        # Check deeply interior cell: r should be 2D ≈ 0.2
+        @test isapprox(r[8, 8], 2 * D; atol = 1e-4)
+        @test isapprox(r[10, 10], 2 * D; atol = 1e-4)
+    end
+
+    @testset "moving step under upwind moves the right way" begin
+        # 1D-ish: step function advecting in +x. After a single step
+        # (φ_new = φ + dt * r), the step front should advance.
+        N = (32, 16)
+        Ng = N .+ 2
+        φ = zeros(Float32, Ng)
+        φ[1:16, :] .= 1f0   # left half
+        u = zeros(Float32, (Ng..., 2))
+        u[:, :, 1] .= 1f0
+        r = similar(φ); Φ = similar(φ)
+        WaterLily.transport!(r, φ, u, Φ; D_diff=0f0)
+        dt = 0.1f0
+        φ_new = φ .+ dt .* r
+        # The mid-row should now have higher values on the right side of
+        # the step than the original.
+        @test sum(@view φ_new[17:20, 8]) > sum(@view φ[17:20, 8])
+    end
+
+end


### PR DESCRIPTION
## What

Adds `transport!(r, φ, u, Φ; D_diff=0, λ=quick, perdir=())` — a cell-centred conservative advection–diffusion residual for a passive scalar, reusing the same QUICK/CDS/vanLeer upwind machinery and ghost-cell conventions as `conv_diff!`. It's intended as a core building block for downstream packages that need scalar advection (VoF α-fields, passive tracers, scalar RANS) without re-implementing the upwind kernel.

The companion helpers `inside_scalar_j`, `scalar_slice`, and the `scalar_lowerBoundary!` / `scalar_upperBoundary!` per-axis kernels keep the orthogonal-ghost row clean. `vanLeer` and `transport!` are added to the exported names.

## Context

This PR originally bundled three downstream-friendly hooks (effective viscosity, scalar transport, Poisson kwargs). Per the review discussion it's been split so each can be reviewed on its own:

- **Scalar transport** — this PR. A generic scalar update equation was felt to belong in the core solver, so it stays here.
- **Variable viscosity** — split out to #291, reworked to compute the effective viscosity on the fly via a closure (no stored array).
- **Poisson solver controls** — to follow as a PR coordinated with #245.

## Tests

`test/transport_test.jl` (wired into the runner) covers uniform-advection conservation, still fluid, pure diffusion, and the moving-step upwind direction. `test/maintests.jl` adds an orthogonal-ghost-cell regression.

<details>
<summary>Original PR description (all three hooks)</summary>

## Motivation

Three small API hooks would let out-of-tree downstream packages compose with WaterLily without forking. This PR adds them, opt-in, with the default code path unchanged when they're not used.

The driving use cases:

- **Turbulence closures** (Smagorinsky, WALE, …) implemented as separate Julia packages that compute a cell-centred eddy viscosity and write it into Flow's effective ν every step.
- **Free-surface VoF** in a separate package, where the molecular ν becomes cell-dependent (water vs air) and a per-cell ν₀ field is the natural interface.
- **Body-force propellers** that want to dial the Poisson solve tolerance up or down depending on simulation phase.

A reference downstream user implementing exactly these closures is at https://github.com/pankgeorg/Turbulence.jl (WALE + Smagorinsky), and the broader stack that needs all three hooks is documented at https://github.com/pankgeorg/foam.

## What's in this PR

### Hook 1 — per-cell array-valued viscosity

`Flow` now accepts `ν::AbstractArray` matching the cell-centred grid size, in addition to the existing scalar `ν::Real`.

Key properties:

- **Stored by reference.** A closure that maintains its own ν array can pass it in once and update in place — the next `mom_step!` sees the new values. (An earlier draft of this work copied the array, which silently broke the LES coupling; the array-by-reference semantics are now tested directly.)
- **Face-averaged viscosity.** The internal `_νf` helper now linearly interpolates to face centres so the viscous flux is consistent for inhomogeneous ν.
- **Wall-integrated friction.** `Metrics.viscous_force` gains an array-ν code path so wall friction reports the correct value.
- **Scalar-BC robustness.** Per-cell ν no longer has its ghost layer silently overwritten by a stored scalar default during BC application.

### Hook 2 — scalar transport! helper

A vanLeer/quick advection routine for cell-centred scalars (VoF α, passive tracers, …) reusing the same upwind kernel as the momentum step. Lets downstream packages reuse the upwind logic without reimplementing it.

### Hook 3 — configurable Poisson tolerance / itmx

`mom_step!` gains `pois_tol` and `pois_itmx` keyword arguments so downstream code can dial multigrid accuracy without forking the solver. Defaults match current behaviour.

## Compatibility

- All three hooks are opt-in. Existing code that doesn't use them runs unchanged.
- No exported names removed; no signature changes to existing methods beyond adding keyword arguments with default values.
- The internal `_νf` change is the only behaviour-affecting refactor; it falls back to scalar behaviour exactly when ν is scalar.

## Tests

- `test/effective_nu_test.jl` (new) — covers scalar/array ν equivalence, per-cell update reaches the momentum equation, face-averaged ν reproduces analytic flux, ghost-cell handling.
- `test/transport_test.jl` (new) — covers scalar advection accuracy and conservation.
- `test/maintests.jl` — array-ν reference-semantics regression plus integration with the existing suite.

All existing tests pass unchanged.

## Note

Happy to split this into three separate per-hook PRs if that's easier to review — they're independent, and each hook stands on its own.

</details>
