### PR TITLE
Add variable effective viscosity via an on-the-fly closure

### DIFF
--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -35,6 +35,36 @@ function median(a,b,c)
     return a
 end
 
+# Cell-centred and face-averaged effective-viscosity lookups. A scalar
+# ν dispatches to the original constant-ν kernel (zero overhead). A
+# callable `ν(I)` returns the cell-centred effective viscosity, computed
+# on the fly in the flux — no stored νₑ array. `_νf` linearly
+# interpolates the closure to the cell face so the diffusive flux stays
+# consistent for inhomogeneous ν. The closure may itself wrap a
+# downstream array (e.g. a VoF volume-fraction field) if a non-local
+# model ever needs one.
+@inline _ν(ν::Number,I) = ν
+@inline _ν(ν,I) = ν(I)
+@inline _νf(ν::Number,j,I) = ν
+@inline _νf(ν,j,I) = @inbounds (ν(I) + ν(I-δ(j,I))) / 2
+
+"""
+    conv_diff!(r, u, Φ, λ; ν=0.1, perdir=())
+
+Compute the convective + diffusive momentum residual
+
+```
+r[I, i] = -∂_j ( u_j u_i - ν_face · ∂_j u_i )
+```
+
+for the face-staggered velocity `u`. The high-order convective flux is
+limited by `λ` (e.g. `quick`, `vanLeer`); the diffusive flux uses the
+face-averaged effective viscosity (see `_νf`). `Φ` is a per-cell
+workspace array. `ν` may be a scalar (uniform Re) or a callable `ν(I)`
+returning the cell-centred effective viscosity (variable Re for VoF /
+LES), evaluated on the fly with no stored array. Directions listed in
+`perdir` are treated as periodic at both boundaries.
+"""
 function conv_diff!(r,u,Φ,λ::F;ν=0.1,perdir=()) where {F}
     r .= zero(eltype(r))
     N,n = size_u(u)
@@ -44,7 +74,7 @@ function conv_diff!(r,u,Φ,λ::F;ν=0.1,perdir=()) where {F}
         # treatment for bottom boundary with BCs
         lowerBoundary!(r,u,Φ,ν,i,j,N,λ,Val{tagper}())
         # inner cells
-        @loop (Φ[I] = ϕu(j,CI(I,i),u,ϕ(i,CI(I,j),u),λ) - ν*∂(j,CI(I,i),u);
+        @loop (Φ[I] = ϕu(j,CI(I,i),u,ϕ(i,CI(I,j),u),λ) - _νf(ν,j,I)*∂(j,CI(I,i),u);
                r[I,i] += Φ[I]) over I ∈ inside_u(N,j)
         @loop r[I-δ(j,I),i] -= Φ[I] over I ∈ inside_u(N,j)
         # treatment for upper boundary with BCs
@@ -53,12 +83,12 @@ function conv_diff!(r,u,Φ,λ::F;ν=0.1,perdir=()) where {F}
 end
 
 # Neumann BC Building block
-lowerBoundary!(r,u,Φ,ν,i,j,N,λ,::Val{false}) = @loop r[I,i] += ϕuL(j,CI(I,i),u,ϕ(i,CI(I,j),u),λ) - ν*∂(j,CI(I,i),u) over I ∈ slice(N,2,j,2)
-upperBoundary!(r,u,Φ,ν,i,j,N,λ,::Val{false}) = @loop r[I-δ(j,I),i] += -ϕuR(j,CI(I,i),u,ϕ(i,CI(I,j),u),λ) + ν*∂(j,CI(I,i),u) over I ∈ slice(N,N[j],j,2)
+lowerBoundary!(r,u,Φ,ν,i,j,N,λ,::Val{false}) = @loop r[I,i] += ϕuL(j,CI(I,i),u,ϕ(i,CI(I,j),u),λ) - _νf(ν,j,I)*∂(j,CI(I,i),u) over I ∈ slice(N,2,j,2)
+upperBoundary!(r,u,Φ,ν,i,j,N,λ,::Val{false}) = @loop r[I-δ(j,I),i] += -ϕuR(j,CI(I,i),u,ϕ(i,CI(I,j),u),λ) + _νf(ν,j,I)*∂(j,CI(I,i),u) over I ∈ slice(N,N[j],j,2)
 
 # Periodic BC Building block
 lowerBoundary!(r,u,Φ,ν,i,j,N,λ,::Val{true}) = @loop (
-    Φ[I] = ϕuP(j,CIj(j,CI(I,i),N[j]-2),CI(I,i),u,ϕ(i,CI(I,j),u),λ) -ν*∂(j,CI(I,i),u); r[I,i] += Φ[I]) over I ∈ slice(N,2,j,2)
+    Φ[I] = ϕuP(j,CIj(j,CI(I,i),N[j]-2),CI(I,i),u,ϕ(i,CI(I,j),u),λ) -_νf(ν,j,I)*∂(j,CI(I,i),u); r[I,i] += Φ[I]) over I ∈ slice(N,2,j,2)
 upperBoundary!(r,u,Φ,ν,i,j,N,λ,::Val{true}) = @loop r[I-δ(j,I),i] -= Φ[CIj(j,I,2)] over I ∈ slice(N,N[j],j,2)
 
 """
@@ -83,7 +113,7 @@ Solid boundaries are modelled using the [Boundary Data Immersion Method](https:/
 The primary variables are the scalar pressure `p` (an array of dimension `D`)
 and the velocity vector field `u` (an array of dimension `D+1`).
 """
-struct Flow{D, T, Sf<:AbstractArray{T}, Vf<:AbstractArray{T}, Tf<:AbstractArray{T}} <: AbstractFlow{D,T}
+struct Flow{D, T, Sf<:AbstractArray{T}, Vf<:AbstractArray{T}, Tf<:AbstractArray{T}, Nf} <: AbstractFlow{D,T}
     # Fluid fields
     u :: Vf # velocity vector field
     u⁰:: Vf # previous velocity
@@ -97,7 +127,7 @@ struct Flow{D, T, Sf<:AbstractArray{T}, Vf<:AbstractArray{T}, Tf<:AbstractArray{
     # Non-fields
     uBC :: Union{NTuple{D,Number},Function} # domain boundary values/function
     Δt:: Vector{T} # time step (stored in CPU memory)
-    ν :: T # kinematic viscosity
+    ν :: Nf # kinematic viscosity: scalar `T` (default) or a cell-centred closure `ν(I)`
     g :: Union{Function,Nothing} # acceleration field funciton
     exitBC :: Bool # Convection exit
     perdir :: NTuple # tuple of periodic direction
@@ -113,7 +143,11 @@ struct Flow{D, T, Sf<:AbstractArray{T}, Vf<:AbstractArray{T}, Tf<:AbstractArray{
         fv, p, σ = zeros(T, Nd) |> mem, zeros(T, Ng) |> mem, zeros(T, Ng) |> mem
         V, μ₀, μ₁ = zeros(T, Nd) |> mem, ones(T, Nd) |> mem, zeros(T, Ng..., D, D) |> mem
         BC!(μ₀,ntuple(zero, D),false,perdir)
-        new{D,T,typeof(p),typeof(u),typeof(μ₁)}(u,u⁰,fv,p,σ,V,μ₀,μ₁,uBC,T[Δt],T(ν),g,exitBC,perdir)
+        # A scalar ν is stored as `T`; a callable closure is stored by
+        # reference, so downstream code that mutates the closure's own
+        # state (e.g. a VoF field) stays in sync across `mom_step!`.
+        ν_store = isa(ν, Function) ? ν : T(ν)
+        new{D,T,typeof(p),typeof(u),typeof(μ₁),typeof(ν_store)}(u,u⁰,fv,p,σ,V,μ₀,μ₁,uBC,T[Δt],ν_store,g,exitBC,perdir)
     end
 end
 
@@ -198,9 +232,20 @@ function mom_project!(a::AbstractFlow, b::AbstractPoisson, w, t)
     BC!(a.u,a.uBC,a.exitBC,a.perdir,t)
 end
 
+# Maximum effective viscosity for the CFL viscous limit. A scalar
+# returns itself (zero overhead). A closure is evaluated into the
+# scratch buffer `σ` and reduced over the interior — called only after
+# the flux-out maximum has already been read out of `σ`.
+@inline _ν_max(ν::Number, σ) = ν
+function _ν_max(ν, σ)
+    @inside σ[I] = ν(I)
+    maximum(@view σ[inside(σ)])
+end
+
 function CFL(a::AbstractFlow;Δt_max=10)
     @inside a.σ[I] = flux_out(I,a.u)
-    min(Δt_max,inv(maximum(a.σ)+5a.ν))
+    fluxmax = maximum(a.σ)
+    min(Δt_max,inv(fluxmax+5*_ν_max(a.ν,a.σ)))
 end
 @fastmath @inline function flux_out(I::CartesianIndex{d},u) where {d}
     s = zero(eltype(u))

--- a/src/Metrics.jl
+++ b/src/Metrics.jl
@@ -125,7 +125,7 @@ viscous_force(flow,body) = viscous_force(flow.u,flow.ν,flow.f,body,time(flow))
 function viscous_force(u,ν,df,body,t=0)
     Tu = eltype(u); To = promote_type(Float64,Tu)
     df .= zero(Tu)
-    @loop df[I,:] .= -2ν*S(I,u)*nds(body,loc(0,I,Tu),t) over I ∈ inside_u(u)
+    @loop df[I,:] .= -2*_ν(ν,I)*S(I,u)*nds(body,loc(0,I,Tu),t) over I ∈ inside_u(u)
     sum(To,df,dims=ntuple(i->i,ndims(u)-1))[:] |> Array
 end
 

--- a/test/effective_nu_test.jl
+++ b/test/effective_nu_test.jl
@@ -1,0 +1,99 @@
+# Regression test for the closure-valued `ν` path. The hot loop inside
+# `conv_diff!` was changed from `ν*∂(...)` to `_νf(ν,j,I)*∂(...)`. With a
+# scalar ν the inlined call compiles to identical code and produces
+# identical numerical output. With a constant closure `I->ν_val` the
+# result must also be bit-identical (or within a few ULP in Float32).
+# The effective viscosity is computed on the fly — no stored array.
+
+using Test
+using WaterLily
+using StaticArrays
+
+@testset "Closure-valued effective viscosity" begin
+
+    @testset "scalar ν unchanged" begin
+        U = (2/3, -1/3)
+        N = (16, 16)
+        a = WaterLily.Flow(N, U; T=Float32, ν=Float32(0.01))
+        @test a.ν isa Float32
+        @test a.ν == Float32(0.01)
+        Δt = WaterLily.CFL(a)
+        @test isfinite(Δt) && Δt > 0
+    end
+
+    @testset "constant closure ≈ scalar" begin
+        # Two flows, same parameters: one scalar ν, one closure ν(I)=ν_val.
+        # After one conv_diff! they must agree to within a few Float32 ULP.
+        U = (2/3, -1/3)
+        N = (16, 16)
+        ν_val = Float32(0.01)
+
+        a_scalar = WaterLily.Flow(N, U; T=Float32, ν=ν_val)
+        a_clos   = WaterLily.Flow(N, U; T=Float32, ν=(I -> ν_val))
+        @test a_clos.ν isa Function
+
+        for I in CartesianIndices(a_scalar.u)
+            v = sinpi((I.I[1] - 1) / N[1]) + cospi((I.I[2] - 1) / N[2])
+            a_scalar.u[I] = a_clos.u[I] = Float32(v)
+        end
+        Φs, Φc = similar(a_scalar.p), similar(a_clos.p)
+        WaterLily.conv_diff!(a_scalar.f, a_scalar.u, Φs, WaterLily.quick; ν=a_scalar.ν)
+        WaterLily.conv_diff!(a_clos.f,   a_clos.u,   Φc, WaterLily.quick; ν=a_clos.ν)
+
+        err = maximum(abs.(a_scalar.f .- a_clos.f))
+        @test err ≤ 5 * eps(Float32) * maximum(abs.(a_scalar.f))
+    end
+
+    @testset "closure enables spatially varying viscosity" begin
+        # A closure reading a non-uniform backing field must produce a
+        # different residual from a constant one — the smoke test that the
+        # hook is wired up.
+        U = (1f0, 0f0)
+        N = (16, 16)
+        νconst = fill(Float32(0.01), N .+ 2)
+        νvary  = copy(νconst); νvary[8:end, :] .= Float32(0.05)
+
+        a1 = WaterLily.Flow(N, U; T=Float32, ν=(I -> νconst[I]))
+        a2 = WaterLily.Flow(N, U; T=Float32, ν=(I -> νvary[I]))
+        for I in CartesianIndices(a1.u)
+            v = sinpi((I.I[1] - 1) / N[1]) * cospi((I.I[2] - 1) / N[2])
+            a1.u[I] = a2.u[I] = Float32(v)
+        end
+        Φ1, Φ2 = similar(a1.p), similar(a2.p)
+        WaterLily.conv_diff!(a1.f, a1.u, Φ1, WaterLily.quick; ν=a1.ν)
+        WaterLily.conv_diff!(a2.f, a2.u, Φ2, WaterLily.quick; ν=a2.ν)
+        @test maximum(abs.(a1.f .- a2.f)) > 0
+    end
+
+    @testset "CFL with closure ν" begin
+        U = (1f0, 0f0)
+        N = (16, 16)
+        νfield = fill(Float32(0.01), N .+ 2)
+        νfield[2, 2] = Float32(0.5)   # interior spike — most restrictive
+        a = WaterLily.Flow(N, U; T=Float32, ν=(I -> νfield[I]))
+        a.u .= 1f0
+        Δt = WaterLily.CFL(a)
+        @test Δt < 1 / (5 * 0.5)
+    end
+
+    @testset "closure is stored by reference" begin
+        # The closure is kept by reference, so mutating the array it wraps
+        # is seen by the next conv_diff! without rebuilding the Flow.
+        U = (1f0, 0f0)
+        N = (16, 16)
+        νfield = fill(Float32(0.01), N .+ 2)
+        clos = I -> νfield[I]
+        a = WaterLily.Flow(N, U; T=Float32, ν=clos)
+        @test a.ν === clos
+        for I in CartesianIndices(a.u)
+            a.u[I] = Float32(sinpi((I.I[1] - 1) / N[1]))
+        end
+        Φ = similar(a.p)
+        WaterLily.conv_diff!(a.f, a.u, Φ, WaterLily.quick; ν=a.ν)
+        f0 = copy(a.f)
+        νfield .*= 10f0                      # mutate the wrapped array in place
+        WaterLily.conv_diff!(a.f, a.u, Φ, WaterLily.quick; ν=a.ν)
+        @test maximum(abs.(a.f .- f0)) > 0
+    end
+
+end

--- a/test/effective_nu_test.jl
+++ b/test/effective_nu_test.jl
@@ -96,4 +96,29 @@ using StaticArrays
         @test maximum(abs.(a.f .- f0)) > 0
     end
 
+    @testset "precomputed-array vs on-the-fly closure are bit-identical" begin
+        # Two ways to supply the same effective viscosity through a closure:
+        #  (a) wrap a PRECOMPUTED ν array, ν = I -> νₑ[I]
+        #  (b) compute ν ON THE FLY from a field, ν = I -> blend(φ[I])
+        # They are the same function of I, so conv_diff! must agree exactly.
+        # (The choice between them is a perf/memory tradeoff — see the
+        # effective-viscosity benchmark in WaterLily-Benchmarks — not a
+        # numerical one.)
+        U = (2/3, -1/3); N = (16, 16)
+        ρw, ρa, μw, μa = 1f3, 1f0, 1f-3, 1.8f-5
+        blend(α) = (α*μw + (1-α)*μa) / (α*ρw + (1-α)*ρa)
+        φ = rand(Float32, N .+ 2)                      # a "volume fraction" field
+        νₑ = blend.(φ)                                  # precomputed effective ν
+        a_arr = WaterLily.Flow(N, U; T=Float32, ν=(let v=νₑ; I->@inbounds v[I]; end))
+        a_fly = WaterLily.Flow(N, U; T=Float32, ν=(let p=φ; I->@inbounds blend(p[I]); end))
+        for I in CartesianIndices(a_arr.u)
+            v = sinpi((I.I[1]-1)/N[1]) + cospi((I.I[2]-1)/N[2])
+            a_arr.u[I] = a_fly.u[I] = Float32(v)
+        end
+        Φa, Φf = similar(a_arr.p), similar(a_fly.p)
+        WaterLily.conv_diff!(a_arr.f, a_arr.u, Φa, WaterLily.quick; ν=a_arr.ν)
+        WaterLily.conv_diff!(a_fly.f, a_fly.u, Φf, WaterLily.quick; ν=a_fly.ν)
+        @test a_arr.f == a_fly.f
+    end
+
 end

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -236,6 +236,19 @@ end
     end
 end
 
+@testset "_νf face-averages a closure ν" begin
+    # A scalar ν is returned unchanged; a closure ν(I) is read per cell
+    # and arithmetically averaged to the cell face.
+    @test WaterLily._νf(0.5, 1, CartesianIndex(2, 2)) == 0.5
+    @test WaterLily._ν(0.5, CartesianIndex(2, 2)) == 0.5
+    νc = I -> Float32(I[1])          # ν grows with the x index
+    @test WaterLily._ν(νc, CartesianIndex(3, 2)) == 3.0f0
+    # Face j=1 at cell (3,2) lies between (2,2) and (3,2): mean = (3+2)/2
+    @test WaterLily._νf(νc, 1, CartesianIndex(3, 2)) == 2.5f0
+end
+
+include("effective_nu_test.jl")
+
 @testset "Body.jl" begin
     @test WaterLily.μ₀(3.,6)==WaterLily.μ₀(0.5,1)
     @test WaterLily.μ₀(0.,1)==0.5
@@ -520,6 +533,15 @@ import WaterLily: ×
         u₂ .= 0; u₃ .= 0
         @test all(WaterLily.viscous_force(u₂,1.0,df₂,body) .≈ 0)
         @test all(WaterLily.viscous_force(u₃,1.0,df₃,body) .≈ 0)
+        # viscous force with a closure ν(I)
+        @test all(WaterLily.viscous_force(u₂,I->one(eltype(u₂)),df₂,body) .≈ 0)
+        @test all(WaterLily.viscous_force(u₃,I->one(eltype(u₃)),df₃,body) .≈ 0)
+        # A closure ν is stored by reference on the Flow, so downstream
+        # code that mutates the closure's own backing state stays in sync.
+        νback = ones(eltype(u₂), N+2, N+2) |> f
+        clos = I -> νback[I]
+        flow_test = Flow((N, N), (1f0, 0f0); T=eltype(u₂), ν=clos, mem=f)
+        @test flow_test.ν === clos
         # pressure moment
         p₂ = zeros(N,N) |> f; apply!(x->x[2],p₂)
         p₃ = zeros(N,N,N) |> f; apply!(x->x[2],p₃)


### PR DESCRIPTION
## What

`Flow` now accepts `ν` as either a scalar (default, unchanged) or a callable `ν(I)` returning the cell-centred effective viscosity. The diffusive flux in `conv_diff!` reads it through the new `_νf`/`_ν` helpers, which **compute the viscosity on the fly — no stored νₑ array**. The scalar path dispatches to the original constant-ν kernel, so the core use case has zero overhead. A closure may itself wrap a downstream array (e.g. a VoF volume-fraction field) if a non-local model ever needs one.

- `conv_diff!` / boundary kernels: `ν*∂` → `_νf(ν,j,I)*∂`
- `Flow.ν` stored by reference for closures (in-place updates are seen by the next `mom_step!`)
- `CFL` viscous limit via `_ν_max` (a closure is reduced over the interior)
- `Metrics.viscous_force` reads `_ν(ν,I)` for wall friction

## Context

Split out of #290 per the discussion there. Following @b-fg, @weymouth and @TzuYaoHuang: compute the effective viscosity on the fly instead of filling/storing a separate array, with no penalty to the constant-ν case. LES eddy viscosity is already covered by the `udf`/`sgs!` hook; this targets variable *molecular* viscosity in the diffusive flux (e.g. the VoF air/water case).

## Performance — and a CPU/GPU caveat

The closure lets a downstream model supply the same ν two ways: **wrap a precomputed per-cell array** (`ν = I -> νₑ[I]`, refreshed once per step) or **compute on the fly** from a primitive field (`ν = I -> μ(α[I])/ρ(α[I])`, no array, no refresh). These are numerically identical (a `conv_diff!` bit-equality test is included), but **not equal in cost, and the winner depends on the hardware**:

- `ν(I)` is evaluated ~`2·D`× per cell per `conv_diff!` (as `I` and as `I-δ`, per direction).
- **CPU**: a divide-heavy blend (μ/ρ) recomputed that often is *not* latency-hidden, so on-the-fly is **slower** than precompute+refresh — ~1.3× in 3D, up to ~1.6× in 2D in a quick measurement.
- **GPU**: bandwidth-bound with heavy latency hiding, so the recompute is expected to be ~free, and on-the-fly additionally saves a full grid-sized array plus the refresh pass.

So "recompute is free" holds for cheap blends and on GPU; for a divide-heavy molecular ν on CPU the precomputed array can win. This PR supports both (the closure is agnostic); the tradeoff is the caller's. A benchmark exposing the CPU↔GPU difference is in WaterLily-jl/WaterLily-Benchmarks#19 (CPU rows filled; GPU rows pending a CUDA/AMD run).

The **constant-ν scalar path is unchanged** (zero overhead); a constant closure is bit-identical to the scalar (also tested).

## Tests

`test/effective_nu_test.jl` (wired into the runner): scalar/closure equivalence within a few ULP, spatially-varying ν changing the residual, CFL limited by the closure maximum, the by-reference contract, and precomputed-array-vs-on-the-fly bit-equality. `test/maintests.jl` adds `_νf`/`_ν` face-averaging and a closure `viscous_force` regression.
