### PR TITLE
add `spread!` function to help initialize 3D sims from 2D

### DIFF
--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -5,6 +5,8 @@ module WaterLily
 
 using DocStringExtensions
 
+abstract type AbstractSimulation end
+
 include("util.jl")
 export L₂,BC!,@inside,inside,δ,apply!,loc,@log,set_backend,backend
 
@@ -28,8 +30,6 @@ export AutoBody,Bodies,measure,sdf,+,-
 
 include("Metrics.jl")
 export MeanFlow,update!,uu!,uu
-
-abstract type AbstractSimulation end
 
 include("RigidMap.jl")
 export RigidMap,setmap

--- a/src/util.jl
+++ b/src/util.jl
@@ -357,6 +357,25 @@ ic_function(uBC::Tuple) = (i,x)->uBC[i]
 
 squeeze(a::AbstractArray) = dropdims(a, dims = tuple(findall(size(a) .== 1)...))
 
+"""
+    spread!(src:AbstractArray{T,N}, dest::AbstractArray{T,N+1}; ϵ=0, dims=3)
+
+Spreads a `N` dim field into a `N+1` field. The parameter `ϵ` sets the random noise added to the spread and
+`dims` specifies the dimension along which the spreading is done.
+
+```julia
+dest = zeros(20,10,5)
+src  = rand(20,10)
+WaterLily.spread!(src, dest; ϵ=0.01, dims=3)
+```
+"""
+function spread!(src::AbstractArray{T}, dest::AbstractArray{T}; dims=3, ϵ=zero(T)) where T
+    @assert(ndims(dest) == ndims(src)+1 && size(src) == ntuple(j -> j<dims ? size(dest,j) : size(dest,j+1), Val(ndims(dest)-1)),
+            "Cannot spread Array src of size $(size(src)) onto Array dest of size $(size(dest)) along dims $(dims)")
+    @loop dest[I] = src[dropindex(I,dims)]+ϵ*rand() over I in CartesianIndices(dest)
+end
+@inline dropindex(I::CartesianIndex{N}, i::Int) where N = CartesianIndex(ntuple(j -> j<i ? I.I[j] : I.I[j+1], Val(N-1)))
+
 using ForwardDiff
 using ForwardDiff: Dual, partials, Tag
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -369,10 +369,9 @@ src  = rand(20,10)
 WaterLily.spread!(src, dest; ϵ=0.01, dims=3)
 ```
 """
-function spread!(src::AbstractArray{T}, dest::AbstractArray{T}; dims=3, ϵ=zero(T)) where T
-    @assert(ndims(dest) == ndims(src)+1 && size(src) == ntuple(j -> j<dims ? size(dest,j) : size(dest,j+1), Val(ndims(dest)-1)),
-            "Cannot spread Array src of size $(size(src)) onto Array dest of size $(size(dest)) along dims $(dims)")
-    @loop dest[I] = src[dropindex(I,dims)]+ϵ*rand() over I in CartesianIndices(dest)
+spread!(src::AbstractArray{T,2}, dest::AbstractArray{T,3}; dims=3, ϵ=zero(T)) where T = (@loop dest[I] = src[dropindex(I,dims)]+ϵ*rand() over I in CartesianIndices(dest))
+spread!(src::AbstractArray{T,3}, dest::AbstractArray{T,4}; dims=3, ϵ=zero(T)) where T = for i in 1:2
+    @loop dest[I,i] = src[dropindex(I,dims),i]+ϵ*rand() over I in CartesianIndices(size(dest)[1:3])
 end
 @inline dropindex(I::CartesianIndex{N}, i::Int) where N = CartesianIndex(ntuple(j -> j<i ? I.I[j] : I.I[j+1], Val(N-1)))
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -358,6 +358,38 @@ ic_function(uBC::Tuple) = (i,x)->uBC[i]
 squeeze(a::AbstractArray) = dropdims(a, dims = tuple(findall(size(a) .== 1)...))
 
 """
+    spread!(sim3D, sim2D; dim=3, ϵ=0)
+
+Spread a given 2D `Simulation` onto a 3D `Simulation` by extruding it along the dim `dim`.
+
+Default is to extrude along the `dim=3`, user can also pass in a given noise level `ϵ` that is
+applied to perturb the velocity field. The pressure field is left unchanged.
+Internally, the function test that that the 3D `Simulation` is exactly an extruded version of
+the 2D Simulation, i.e. the body must match through μ₀.
+
+Example:
+```julia
+# 2D or 3D cylinder
+body = AutoBody((x,t)->√sum(abs2,SA[x[1]-8,x[2]-8])-6)
+# the sims
+sim2D = Simulation((32,16)  ,(1.0,0.0)    ,1.0;body)
+sim3D = Simulation((32,16,8),(1.0,0.0,0.0),1.0;body,perdir=(3,))
+# spread after a few steps
+sim_step!(sim2D,100)
+WaterLily.spread!(sim3D, sim2D; dim=3, ϵ=0.0)
+```
+"""
+function spread!(sim3D::AbstractSimulation, sim2D::AbstractSimulation; dim=3, ϵ=0)
+    T,S = eltype(sim2D.flow.p), size(sim3D.flow.p)
+    size3D = ntuple(j->j<dim ? S[j] : S[j+1], 2)
+    @assert size(sim2D.flow.p)==size3D "Spread dimensions mismatch between sim2D $(size(sim2D.flow.p)) and sim3D $(size3D) for dim $(dim)"
+    Is = CartesianIndices(((ntuple(j->j==dim ? (1:1) : (1:S[j]), 3))..., 1:2))
+    @assert all(sim2D.flow.μ₀ .≈ squeeze(sim3D.flow.μ₀[Is])) "There seem to be a body mistmatch between the body in the sim2D and the sim3D along dim $(dim)"
+    spread!(sim3D.flow.p, sim2D.flow.p; dim=dim, ϵ=zero(T))
+    spread!(sim3D.flow.u, sim2D.flow.u; dim=dim, ϵ=T(ϵ))
+end
+
+"""
     spread!(src:AbstractArray{T,N}, dest::AbstractArray{T,N+1}; ϵ=0, dims=3)
 
 Spreads a `N` dim field into a `N+1` field. The parameter `ϵ` sets the random noise added to the spread and
@@ -369,9 +401,9 @@ src  = rand(20,10)
 WaterLily.spread!(src, dest; ϵ=0.01, dims=3)
 ```
 """
-spread!(src::AbstractArray{T,2}, dest::AbstractArray{T,3}; dims=3, ϵ=zero(T)) where T = (@loop dest[I] = src[dropindex(I,dims)]+ϵ*rand() over I in CartesianIndices(dest))
-spread!(src::AbstractArray{T,3}, dest::AbstractArray{T,4}; dims=3, ϵ=zero(T)) where T = for i in 1:2
-    @loop dest[I,i] = src[dropindex(I,dims),i]+ϵ*rand() over I in CartesianIndices(size(dest)[1:3])
+spread!(dest::AbstractArray{T,3}, src::AbstractArray{T,2}; dim=3, ϵ=zero(T)) where T = (@loop dest[I] = src[dropindex(I,dim)]+ϵ*rand() over I in CartesianIndices(dest))
+spread!(dest::AbstractArray{T,4}, src::AbstractArray{T,3}; dim=3, ϵ=zero(T)) where T = for i in 1:2
+    @loop dest[I,i] = src[dropindex(I,dim),i]+ϵ*rand() over I in CartesianIndices(size(dest)[1:3])
 end
 @inline dropindex(I::CartesianIndex{N}, i::Int) where N = CartesianIndex(ntuple(j -> j<i ? I.I[j] : I.I[j+1], Val(N-1)))
 

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -108,17 +108,30 @@ backend != "KernelAbstractions" && throw(ArgumentError("SIMD backend not allowed
         # test spread!, 2D scalar field into a 3D scalar
         src2 = rand(2,3) |> f
         dest3 = zeros(2,3,4) |> f
-        WaterLily.spread!(src2, dest3; dims=3)
-        @test all(dest3[:,:,1] .== dest3[:,:,2] .== dest3[:,:,3] .== dest3[:,:,4] .== src2)
+        WaterLily.spread!(dest3, src2; dim=3)
+        @test GPUArrays.@allowscalar all(dest3[:,:,1] .≈ dest3[:,:,2] .≈ dest3[:,:,3] .≈ dest3[:,:,4] .≈ src2)
         # same for a vector field
         src2 = rand(2,3,2) |> f
         dest3 = zeros(2,3,4,3) |> f
-        WaterLily.spread!(src2, dest3; dims=3)
-        @test all(dest3[:,:,1,1:2] .== dest3[:,:,2,1:2] .== dest3[:,:,3,1:2] .== dest3[:,:,4,1:2] .== src2)
+        WaterLily.spread!(dest3, src2; dim=3)
+        @test GPUArrays.@allowscalar all(dest3[:,:,1,1:2] .≈ dest3[:,:,2,1:2] .≈ dest3[:,:,3,1:2] .≈ dest3[:,:,4,1:2] .≈ src2)
         # errors when dimensions are incompatible
-        @test_throws MethodError WaterLily.spread!(src2, src2; dims=3)           # same dims
-        @test_throws MethodError WaterLily.spread!(src2, zeros(2, 2, 4); dims=3) # mismatched non-spread axis
-        @test_throws MethodError WaterLily.spread!(dest3, src2; dims=1)          # wrong order of fields
+        @test_throws MethodError WaterLily.spread!(src2, src2; dim=3)           # same dims
+        @test_throws MethodError WaterLily.spread!(zeros(2, 2, 4), src2; dim=3) # mismatched non-spread axis
+        @test_throws MethodError WaterLily.spread!(src2, dest3; dim=1)          # wrong order of fields
+        # test on Simulations
+        body = AutoBody((x,t)->√sum(abs2,SA[x[1]-8,x[2]-8])-6)
+        sim2D = Simulation((32,16),(1.0,0.0),1.0;body,mem=f)
+        apply!(x->x[1],sim2D.flow.p); apply!((i,x)->x[i],sim2D.flow.u)
+        sim3D = Simulation((32,16,8),(1.0,0.0,0.0),1.0;body,perdir=(3,),mem=f)
+        WaterLily.spread!(sim3D, sim2D; dim=3, ϵ=0.0)
+        # check at a few location along dims
+        @test GPUArrays.@allowscalar all(sim3D.flow.u[:,:,1,1:2] .≈ sim3D.flow.u[:,:,3,1:2] .≈ sim3D.flow.u[:,:,6,1:2] .≈ sim3D.flow.u[:,:,8,1:2] .≈ sim2D.flow.u)
+        @test GPUArrays.@allowscalar all(sim3D.flow.p[:,:,1] .≈ sim3D.flow.p[:,:,3] .≈ sim3D.flow.p[:,:,6] .≈ sim3D.flow.p[:,:,8] .≈ sim2D.flow.p)
+        @test_throws AssertionError WaterLily.spread!(sim3D, sim2D; dim=1)
+        # body mis-match should throw an AssertionError
+        sim3D = Simulation((32,16,8),(1.0,0.0,0.0),1.0;body=AutoBody((x,t)->√sum(abs2,x.-8)-6),perdir=(3,),mem=f)
+        @test_throws AssertionError WaterLily.spread!(sim3D, sim2D; dim=3)
     end
 end
 

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -111,14 +111,14 @@ backend != "KernelAbstractions" && throw(ArgumentError("SIMD backend not allowed
         WaterLily.spread!(src2, dest3; dims=3)
         @test all(dest3[:,:,1] .== dest3[:,:,2] .== dest3[:,:,3] .== dest3[:,:,4] .== src2)
         # same for a vector field
-        src2 = rand(2,3,3) |> f
+        src2 = rand(2,3,2) |> f
         dest3 = zeros(2,3,4,3) |> f
         WaterLily.spread!(src2, dest3; dims=3)
-        @test all(dest3[:,:,1,:] .== dest3[:,:,2,:] .== dest3[:,:,3,:] .== dest3[:,:,4,:] .== src2)
+        @test all(dest3[:,:,1,1:2] .== dest3[:,:,2,1:2] .== dest3[:,:,3,1:2] .== dest3[:,:,4,1:2] .== src2)
         # errors when dimensions are incompatible
-        @test_throws AssertionError WaterLily.spread!(src2, src2; dims=3)           # same dims
-        @test_throws AssertionError WaterLily.spread!(src2, zeros(2, 2, 4); dims=3) # mismatched non-spread axis
-        @test_throws AssertionError WaterLily.spread!(dest3, src2; dims=1)          # wrong order of fields
+        @test_throws MethodError WaterLily.spread!(src2, src2; dims=3)           # same dims
+        @test_throws MethodError WaterLily.spread!(src2, zeros(2, 2, 4); dims=3) # mismatched non-spread axis
+        @test_throws MethodError WaterLily.spread!(dest3, src2; dims=1)          # wrong order of fields
     end
 end
 

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -104,6 +104,21 @@ backend != "KernelAbstractions" && throw(ArgumentError("SIMD backend not allowed
         @test GPUArrays.@allowscalar WaterLily.perdot(σ1,σ2,())    ≈ sum(σ1[I]*σ2[I] for I∈CartesianIndices(σ1))
         @test GPUArrays.@allowscalar WaterLily.perdot(σ1,σ2,(1,))  ≈ sum(σ1[I]*σ2[I] for I∈inside(σ1))
         @test GPUArrays.@allowscalar WaterLily.perdot(σ1,σ2,(1,2)) ≈ sum(σ1[I]*σ2[I] for I∈inside(σ1))
+
+        # test spread!, 2D scalar field into a 3D scalar
+        src2 = rand(2,3) |> f
+        dest3 = zeros(2,3,4) |> f
+        WaterLily.spread!(src2, dest3; dims=3)
+        @test all(dest3[:,:,1] .== dest3[:,:,2] .== dest3[:,:,3] .== dest3[:,:,4] .== src2)
+        # same for a vector field
+        src2 = rand(2,3,3) |> f
+        dest3 = zeros(2,3,4,3) |> f
+        WaterLily.spread!(src2, dest3; dims=3)
+        @test all(dest3[:,:,1,:] .== dest3[:,:,2,:] .== dest3[:,:,3,:] .== dest3[:,:,4,:] .== src2)
+        # errors when dimensions are incompatible
+        @test_throws AssertionError WaterLily.spread!(src2, src2; dims=3)           # same dims
+        @test_throws AssertionError WaterLily.spread!(src2, zeros(2, 2, 4); dims=3) # mismatched non-spread axis
+        @test_throws AssertionError WaterLily.spread!(dest3, src2; dims=1)          # wrong order of fields
     end
 end
 


### PR DESCRIPTION
This PR implements a `spread!` function that allows spreading any `Array{T,N}` onto an `Array{T,N+1}` along a certain `dims`.

This is helpful for spanwise-related simulations where a 2D velocity and pressure field can be extruded and fill the 3D fields.

```julia
sim2D = Simulation((32,32), (1,0), 1; U=1, Δt=0.1, ν=0.01)
sim2D.flow.u .= rand(size(sim2D.flow.u)...)
sim2D.flow.p .= rand(size(sim2D.flow.p)...)
sim3D = Simulation((32,32,32), (1,0,0), 1; U=1, Δt=0.1, ν=0.01)
# spread to initalize
WaterLily.spread!(sim2D.flow.p, sim3D.flow.p; dims=3)
WaterLily.spread!(sim2D.flow.u, sim3D.flow.u; dims=3)
```