### PR TITLE
Adding viscous_moment and total_moment to compute moment about centre 

### DIFF
--- a/src/Metrics.jl
+++ b/src/Metrics.jl
@@ -152,6 +152,28 @@ function pressure_moment(x₀,p,df,body,t=0)
 end
 
 """
+    viscous_moment(x₀,sim::Simulation)
+
+Computes the viscous moment on an immersed body relative to point x₀.
+"""
+viscous_moment(x₀,sim) = viscous_moment(x₀,sim.flow,sim.body)
+viscous_moment(x₀,flow,body) = viscous_moment(x₀,flow.u,flow.ν,flow.f,body,time(flow))
+function viscous_moment(x₀,u,ν,df,body,t=0)
+    Tu = eltype(u); To = promote_type(Float64,Tu)
+    df .= zero(Tu)
+    @loop df[I,:] .= -2ν*cross(loc(0,I,Tu)-x₀,S(I,u)*nds(body,loc(0,I,Tu),t)) over I ∈ inside_u(u)
+    sum(To,df,dims=ntuple(i->i,ndims(u)-1))[:] |> Array
+end
+
+"""
+    total_moment(x₀,sim::Simulation)
+
+Compute the total moment on an immersed body.
+"""
+total_moment(x₀,sim) = pressure_moment(x₀,sim) .+ viscous_moment(x₀,sim)
+
+
+"""
     MeanFlow{T, Sf<:AbstractArray{T}, Vf<:AbstractArray{T}, Mf<:AbstractArray{T}}
 
 Holds temporal averages of pressure, velocity, and squared-velocity tensor.

--- a/src/Metrics.jl
+++ b/src/Metrics.jl
@@ -168,7 +168,7 @@ end
 """
     total_moment(x₀,sim::Simulation)
 
-Compute the total moment on an immersed body.
+Computes the total (pressure + viscous) moment on an immersed body relative to point x₀.
 """
 total_moment(x₀,sim) = pressure_moment(x₀,sim) .+ viscous_moment(x₀,sim)
 

--- a/test/test_metrics.jl
+++ b/test/test_metrics.jl
@@ -44,6 +44,10 @@ import WaterLily: ×
         u₂ .= 0; u₃ .= 0
         @test all(WaterLily.viscous_force(u₂,1.0,df₂,body) .≈ 0)
         @test all(WaterLily.viscous_force(u₃,1.0,df₃,body) .≈ 0)
+        # viscous moment
+        u₂ .= 0; u₃ .= 0
+        @test all(WaterLily.viscous_moment(SVector{2,Float64}(N/2,N/2),u₂,1.0,df₂,body) .≈ 0)
+        @test all(WaterLily.viscous_moment(SVector{3,Float64}(N/2,N/2,N/2),u₃,1.0,df₃,body) .≈ 0)
         # pressure moment
         p₂ = zeros(N,N) |> f; apply!(x->x[2],p₂)
         p₃ = zeros(N,N,N) |> f; apply!(x->x[2],p₃)


### PR DESCRIPTION
Adding viscous_moment and total_moment to compute moment about a given centre x0 from viscous forces on the surface normal.

Also adding total_moment as sum of pressure_moment and total_moment

 On branch feature/viscous_moment
 Changes to be committed:
	modified:   src/Metrics.jl
	modified:   test/test_metrics.jl

Fixing #300 

PS
Addition of metric seemed straightforward enough performance test is not performed.