### PR TITLE
Rename initial-condition keyword `uλ` → `u0` (with deprecation warning)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "WaterLily"
 uuid = "ed894a53-35f9-47f1-b17f-85db9237eebd"
 authors = ["Gabriel Weymouth <gabriel.weymouth@gmail.com>"]
-version = "1.7.0"
+version = "1.8.0"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -91,6 +91,8 @@ ic_function(uBC::Tuple) = (i,x)->uBC[i]
 Resolve the initial-condition keyword argument. `uλ` is the deprecated name for `u0`:
 if it is supplied a deprecation warning is emitted and its value is used only when `u0`
 is not given. Returns the effective initial condition (possibly `nothing`).
+
+Remove this function in WL 2.0
 """
 function ic_kwarg(u0, uλ)
     isnothing(uλ) && return u0
@@ -129,7 +131,7 @@ struct Flow{D, T, Sf<:AbstractArray{T}, Vf<:AbstractArray{T}, Tf<:AbstractArray{
     perdir :: NTuple # tuple of periodic direction
     function Flow(N::NTuple{D}, uBC; mem=Array, Δt=0.25, ν=0., g=nothing,
             u0=nothing, uλ=nothing, perdir=(), exitBC=false, T=Float32) where D
-        u0 = ic_kwarg(u0, uλ)
+        u0 = ic_kwarg(u0, uλ) # to be removed in v2.0
         Ng = N .+ 2
         Nd = (Ng..., D)
         isnothing(u0) && (u0 = ic_function(uBC))

--- a/src/Flow.jl
+++ b/src/Flow.jl
@@ -85,6 +85,19 @@ applyS!(f,c) = @loop c[I] = f(loc(0,I,eltype(c))) over I ∈ CartesianIndices(c)
 ic_function(uBC::Function) = (i,x)->uBC(i,x,0)
 ic_function(uBC::Tuple) = (i,x)->uBC[i]
 
+"""
+    ic_kwarg(u0, uλ)
+
+Resolve the initial-condition keyword argument. `uλ` is the deprecated name for `u0`:
+if it is supplied a deprecation warning is emitted and its value is used only when `u0`
+is not given. Returns the effective initial condition (possibly `nothing`).
+"""
+function ic_kwarg(u0, uλ)
+    isnothing(uλ) && return u0
+    @warn "The `uλ` keyword argument is deprecated and will be removed in a future release. Use `u0` instead." maxlog=1
+    isnothing(u0) ? uλ : u0
+end
+
 abstract type AbstractFlow{D,T} end
 """
     Flow{D::Int, T::Float, Sf<:AbstractArray{T,D}, Vf<:AbstractArray{T,D+1}, Tf<:AbstractArray{T,D+2}}
@@ -115,12 +128,13 @@ struct Flow{D, T, Sf<:AbstractArray{T}, Vf<:AbstractArray{T}, Tf<:AbstractArray{
     exitBC :: Bool # Convection exit
     perdir :: NTuple # tuple of periodic direction
     function Flow(N::NTuple{D}, uBC; mem=Array, Δt=0.25, ν=0., g=nothing,
-            uλ=nothing, perdir=(), exitBC=false, T=Float32) where D
+            u0=nothing, uλ=nothing, perdir=(), exitBC=false, T=Float32) where D
+        u0 = ic_kwarg(u0, uλ)
         Ng = N .+ 2
         Nd = (Ng..., D)
-        isnothing(uλ) && (uλ = ic_function(uBC))
+        isnothing(u0) && (u0 = ic_function(uBC))
         u = Array{T}(undef, Nd...) |> mem
-        isa(uλ, Function) ? apply!(uλ, u) : apply!((i,x)->uλ[i], u)
+        isa(u0, Function) ? apply!(u0, u) : apply!((i,x)->u0[i], u)
         BC!(u,uBC,exitBC,perdir); exitBC!(u,u,zero(T))
         u⁰ = copy(u)
         fv, p, σ = zeros(T, Nd) |> mem, zeros(T, Ng) |> mem, zeros(T, Ng) |> mem

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -38,8 +38,8 @@ export RigidMap,setmap
 
 """
     Simulation(dims::NTuple, uBC::Union{NTuple,Function}, L::Number;
-               U=norm2(Uλ), Δt=0.25, ν=0., ϵ=1, g=nothing,
-               perdir=(), exitBC=false,
+               U=nothing, Δt=0.25, ν=0., ϵ=1, g=nothing,
+               u0=nothing, perdir=(), exitBC=false,
                body::AbstractBody=NoBody(),
                T=Float32, mem=Array,
                flow_ctor=(dims,uBC;kw...)->Flow(dims,uBC;kw...),
@@ -51,14 +51,15 @@ Constructor for a WaterLily.jl simulation:
   - `uBC`: Velocity field applied to boundary and acceleration conditions.
         Define a `Tuple` for constant BCs, or a `Function` for space and time varying BCs `uBC(i,x,t)`.
   - `L`: Simulation length scale.
-  - `U`: Simulation velocity scale. Required if using `Uλ::Function`.
+  - `U`: Simulation velocity scale. Required if using `uBC::Function`.
   - `Δt`: Initial time step.
   - `ν`: Scaled viscosity (`Re=UL/ν`).
   - `g`: Domain acceleration, `g(i,x,t)=duᵢ/dt`
   - `ϵ`: BDIM kernel width.
   - `perdir`: Domain periodic boundary condition in the `(i,)` direction.
-  - `uλ`: Velocity field applied to the initial condition.
-        Define a Tuple for homogeneous (per direction) IC, or a `Function` for space varying IC `uλ(i,x)`.
+  - `u0`: Velocity field applied to the initial condition.
+        Define a Tuple for homogeneous (per direction) IC, or a `Function` for space varying IC `u0(i,x)`.
+        The deprecated `uλ` keyword is still accepted as an alias and will be removed in a future release.
   - `exitBC`: Convective exit boundary condition in the `i=1` direction.
   - `body`: Immersed geometry.
   - `T`: Array element type.
@@ -89,14 +90,15 @@ mutable struct Simulation <: AbstractSimulation
     pois :: AbstractPoisson
     function Simulation(dims::NTuple{N}, uBC, L::Number;
                         Δt=0.25, ν=0., g=nothing, U=nothing, ϵ=1, perdir=(),
-                        uλ=nothing, exitBC=false, body::AbstractBody=NoBody(),
+                        u0=nothing, uλ=nothing, exitBC=false, body::AbstractBody=NoBody(),
                         flow_ctor=(dims,uBC;kw...)->Flow(dims,uBC;kw...),
                         pois_ctor=flow->MultiLevelPoisson(flow.p,flow.μ₀,flow.σ;perdir),
                         T=Float32, mem=Array) where N
         @assert !(isnothing(U) && isa(uBC,Function)) "`U` (velocity scale) must be specified if boundary conditions `uBC` is a `Function`"
         isnothing(U) && (U = √sum(abs2,uBC))
-        check_fn(uBC,N,T,3); check_fn(g,N,T,3); check_fn(uλ,N,T,2)
-        flow = flow_ctor(dims,uBC;uλ,Δt,ν,g,T,mem,perdir,exitBC)
+        u0 = ic_kwarg(u0, uλ)
+        check_fn(uBC,N,T,3); check_fn(g,N,T,3); check_fn(u0,N,T,2)
+        flow = flow_ctor(dims,uBC;u0,Δt,ν,g,T,mem,perdir,exitBC)
         measure!(flow,body;ϵ)
         new(U,L,ϵ,flow,body,pois_ctor(flow))
     end

--- a/test/test_simulation.jl
+++ b/test/test_simulation.jl
@@ -52,4 +52,23 @@
     @test sim.pois isa MultiLevelPoisson
     sim_step!(sim,0.5,remeasure=false)
     @test all(isfinite, sim.flow.u)
+
+    # Initial-condition keyword `u0` and its deprecated alias `uλ`
+    ic(i,x) = i==1 ? 2.0f0 : 0.0f0
+    zeroic(i,x) = 0.0f0
+    # `u0` sets the interior initial velocity
+    simu0 = Simulation((16,16),(1,0),16; u0=ic, T=Float32)
+    @test all(≈(2.0f0), simu0.flow.u[3:14,3:14,1])
+    # `uλ` is a deprecated alias for `u0`: it warns once and gives the same field
+    local simuλ
+    @test_logs (:warn, r"uλ.*deprecated") match_mode=:any begin
+        simuλ = Simulation((16,16),(1,0),16; uλ=ic, T=Float32)
+    end
+    @test simuλ.flow.u == simu0.flow.u
+    # `u0` takes precedence over `uλ` when both are supplied
+    simboth = Simulation((16,16),(1,0),16; u0=ic, uλ=zeroic, T=Float32)
+    @test simboth.flow.u == simu0.flow.u
+    # the resolver returns the active initial condition
+    @test WaterLily.ic_kwarg(ic, nothing) === ic
+    @test WaterLily.ic_kwarg(nothing, nothing) === nothing
 end

--- a/test/test_simulation.jl
+++ b/test/test_simulation.jl
@@ -54,16 +54,14 @@
     @test all(isfinite, sim.flow.u)
 
     # Initial-condition keyword `u0` and its deprecated alias `uλ`
+    # Test to be removed in WL 2.0
     ic(i,x) = i==1 ? 2.0f0 : 0.0f0
     zeroic(i,x) = 0.0f0
     # `u0` sets the interior initial velocity
     simu0 = Simulation((16,16),(1,0),16; u0=ic, T=Float32)
     @test all(≈(2.0f0), simu0.flow.u[3:14,3:14,1])
     # `uλ` is a deprecated alias for `u0`: it warns once and gives the same field
-    local simuλ
-    @test_logs (:warn, r"uλ.*deprecated") match_mode=:any begin
-        simuλ = Simulation((16,16),(1,0),16; uλ=ic, T=Float32)
-    end
+    simuλ = @test_logs (:warn, r"uλ.*deprecated") match_mode=:any Simulation((16,16),(1,0),16; uλ=ic, T=Float32)
     @test simuλ.flow.u == simu0.flow.u
     # `u0` takes precedence over `uλ` when both are supplied
     simboth = Simulation((16,16),(1,0),16; u0=ic, uλ=zeroic, T=Float32)


### PR DESCRIPTION
## Summary

Renames the initial-condition keyword argument of `Simulation` (and `Flow`) from `uλ` to the more discoverable `u0`.

This is **backward compatible**: `uλ` still works as an alias but now emits a one-time deprecation warning hinting users to switch to `u0`:

```
┌ Warning: The `uλ` keyword argument is deprecated and will be removed in a future release. Use `u0` instead.
└ @ WaterLily ~/.../src/Flow.jl
```

When both are supplied, `u0` takes precedence.

## Changes

- Add `ic_kwarg(u0, uλ)` resolver in `src/Flow.jl` that emits the deprecation warning and resolves precedence.
- `Simulation` and `Flow` now accept `u0`; `Simulation` forwards `u0` to `flow_ctor`/`Flow`.
- Update the `Simulation` docstring to document `u0` (and fix stale `Uλ` references for the velocity scale).
- Tests in `test/test_simulation.jl` covering `u0`, the `uλ` alias warning, and `u0`-over-`uλ` precedence.
- Version bump `1.7.0` → `1.8.0` (backward-compatible feature).

## Ecosystem follow-up

`Simulation` now forwards `u0` (not `uλ`) to `flow_ctor`, so downstream packages that define a custom flow constructor must accept `u0`. Companion PRs renaming `uλ` → `u0` will follow in WaterLily-Examples and any affected ecosystem repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)