### PR TITLE
viz!: add `img` kwarg to save image(s) of rendered frames

### DIFF
--- a/ext/WaterLilyMakieExt.jl
+++ b/ext/WaterLilyMakieExt.jl
@@ -1,6 +1,6 @@
 module WaterLilyMakieExt
 
-using Makie, WaterLily, ForwardDiff
+using Makie, WaterLily, ForwardDiff, Printf
 using Makie.GeometryBasics, Makie.PlotUtils
 using ForwardDiff: Dual, value
 import WaterLily: viz!, get_body, plot_body_obs!
@@ -87,7 +87,7 @@ plot_σ_obs!(ax, σ::Observable{Array{T,3}} where T; kwargs...) = Makie.volume!(
         λ=quick, udf=nothing, udf_kwargs=nothing,
         d=ndims(sim.flow.p), CIs=nothing, cut=nothing, tidy_colormap=true,
         body=!(typeof(sim.body)<:WaterLily.NoBody), body_color=:grey, body2mesh=false,
-        video=nothing, hidedecorations=false, elevation=π/8, azimuth=1.275π, framerate=60, compression=5,
+        video=nothing, img=nothing, hidedecorations=false, elevation=π/8, azimuth=1.275π, framerate=60, compression=5,
         theme=nothing, fig_size=nothing, fig_pad=10, kwargs...)
 
 General visualization routine to simulate and render the flow field using Makie.
@@ -129,7 +129,15 @@ Keyword arguments:
     - `body2mesh::Bool`: The body is plotted by generating a GeometryBasics.mesh, otherwise just as a Makie.volume (faster).
         Note that Meshing and GeometryBasics packages must be loaded if `body2mesh=true`.
     - `body_color`: Body color, can also containt alpha value, eg (:black, 0.9)
-    - `video::String`: Save the simulation as as video, instead of rendering. Defaults to `nothing` (not saving video).
+    - `video::String`: Save the simulation as a video to this path instead of rendering interactively. Parent directories are
+        created as needed and the saved path is printed. Defaults to `nothing` (not saving video).
+    - `img`: Save rendered frame(s) as image file(s). Pass a filename `String` with a `.png` extension to save with the
+        active backend, e.g. `img="frame.png"`. To save a `.svg` or `.pdf`, pass a `(name, backend)` tuple where `backend` is a
+        loaded Makie backend that supports vector output (CairoMakie), e.g. `img=("frame.svg", CairoMakie)`; passing a `.svg`/`.pdf`
+        name without a backend errors. If `name` contains a printf integer placeholder (e.g. `img="frame_%04d.png"` or
+        `img=("frame_%04d.svg", CairoMakie)`), one image is saved per simulation frame (like `video`, rendered offscreen with no
+        interactive window); otherwise only the last rendered frame is saved. Parent directories are created as needed, and the
+        saved path (single image) or parent directory (series) is printed. Can be combined with `video`. Defaults to `nothing`.
     - `hidedecorations::Bool`: Figures without axis details.
     - `azimuth::Number`: Camera azimuth angle. Find a suitable angle interactively checking `ax.azimuth.val`
     - `elevation::Number`: Camera elevation angle. Find a suitable angle interactively checking `ax.elevation.val`.
@@ -146,7 +154,7 @@ function viz!(sim; f=nothing, duration=nothing, step=0.1, remeasure=true, verbos
     λ=quick, udf=nothing, udf_kwargs=nothing,
     d=ndims(sim.flow.p), CIs=nothing, cut=nothing, sym=nothing, tidy_colormap=true,
     body=!(typeof(sim.body)<:WaterLily.NoBody), body_color=:grey, body2mesh=false,
-    video=nothing, hidedecorations=false, elevation=π/8, azimuth=1.275π, framerate=60, compression=5,
+    video=nothing, img=nothing, hidedecorations=false, elevation=π/8, azimuth=1.275π, framerate=60, compression=5,
     theme=nothing, fig_size=nothing, fig_pad=10, fig=nothing, ax=nothing, kwargs...)
 
     function update_data()
@@ -167,6 +175,7 @@ function viz!(sim; f=nothing, duration=nothing, step=0.1, remeasure=true, verbos
 
     d==2 && (@assert !(body2mesh) "body2mesh only allowed for 3D plots (d=3).")
     body2mesh && (@assert !isnothing(Base.get_extension(WaterLily, :WaterLilyMeshingExt)) "If body2mesh=true, Meshing must be loaded.")
+    img_name, img_backend, img_fmt = parse_img(img) # validate and unpack the image spec; img_fmt set => save one image per frame
     D = ndims(sim.flow.σ)
     @assert d <= D "Cannot do a 3D plot on a 2D simulation."
     !isnothing(sym) && @assert length(sym) == d "sym kwarg must have length equal to plot dimension d=$d, got $(length(sym))."
@@ -228,21 +237,29 @@ function viz!(sim; f=nothing, duration=nothing, step=0.1, remeasure=true, verbos
     if !isnothing(duration) # time loop for animation
         t₀ = round(WaterLily.sim_time(sim))
         if !isnothing(video)
+            vdir = dirname(video); isempty(vdir) || mkpath(vdir)
             Makie.record(fig, video; framerate, compression) do frame
-                for tᵢ in range(t₀,t₀+duration;step)
+                for (i,tᵢ) in enumerate(range(t₀,t₀+duration;step))
                     step_sim_and_viz!(sim,tᵢ)
                     recordframe!(frame)
+                    isnothing(img_fmt) || save_img(Printf.format(img_fmt,i), img_backend, fig)
                 end
             end
+            println("Video saved to $(abspath(video))")
         else
-            new_fig && display(Makie.current_backend().Screen(), fig)
-            for tᵢ in range(t₀,t₀+duration;step)
+            new_fig && isnothing(img_fmt) && display(Makie.current_backend().Screen(), fig) # an image series renders offscreen
+            for (i,tᵢ) in enumerate(range(t₀,t₀+duration;step))
                 step_sim_and_viz!(sim,tᵢ)
+                isnothing(img_fmt) || save_img(Printf.format(img_fmt,i), img_backend, fig)
             end
         end
+        isnothing(img_fmt) && save_img(img_name, img_backend, fig) # single image: save the last frame (a series is saved in the loop)
+        report_img(img_name, img_fmt)
         return fig, ax
     end
-    new_fig && display(Makie.current_backend().Screen(), fig)
+    new_fig && isnothing(img_fmt) && display(Makie.current_backend().Screen(), fig)
+    save_img(isnothing(img_fmt) ? img_name : Printf.format(img_fmt,1), img_backend, fig) # the single rendered frame
+    report_img(img_name, img_fmt)
     return fig, ax
 end
 function viz!(sim, a::AbstractArray; kwargs...)
@@ -292,6 +309,52 @@ function mirror_sym!(dst::AbstractArray{T,N}, src::AbstractArray{S,N}, sym) wher
         dst[I] = src[J]
     end
     return dst
+end
+
+"""
+    parse_img(img)
+
+Validate and unpack the `img` image-saving spec into `(name, backend, fmt)`. `img` is either a filename `String`
+(saved with the active backend, must be `.png`) or a `(name, backend)` tuple (the backend must support the requested
+extension, e.g. CairoMakie for `.svg`/`.pdf`). If `name` contains a printf integer placeholder (eg. `frame_%04d.png`),
+`fmt` is a `Printf.Format` and one image is saved per simulation frame; otherwise `fmt` is `nothing` (single last frame).
+Returns `(nothing, nothing, nothing)` when `img === nothing`.
+"""
+function parse_img(img)
+    isnothing(img) && return nothing, nothing, nothing
+    explicit_backend = img isa Tuple
+    name, backend = explicit_backend ? (img[1], img[2]) : (img, Makie.current_backend())
+    ext = lowercase(splitext(name)[2])
+    @assert ext in (".png", ".svg", ".pdf") "img name must end in .png, .svg, or .pdf, got \"$name\"."
+    @assert explicit_backend || ext == ".png" "Saving a $ext image requires a Makie backend that supports it: pass it as a (name, backend) tuple, eg. img=(\"$name\", CairoMakie). Without a backend only .png is supported."
+    fmt = occursin('%', name) ? Printf.Format(name) : nothing # `frame_%04d.png` -> one image per frame
+    return name, backend, fmt
+end
+
+"""
+    save_img(name, backend, fig)
+
+Save `fig` to `name` with `backend`, creating the parent directory if needed. Returns the absolute path,
+or `nothing` (no-op) when `name === nothing`.
+"""
+function save_img(name, backend, fig)
+    isnothing(name) && return nothing
+    dir = dirname(name); isempty(dir) || mkpath(dir)
+    Makie.save(name, fig; backend)
+    return abspath(name)
+end
+
+"""
+    report_img(name, fmt)
+
+Print where image output landed: a single image (`fmt === nothing`) prints its absolute path; an image series
+prints its absolute parent directory. No-op when `name === nothing`.
+"""
+function report_img(name, fmt)
+    isnothing(name) && return
+    isnothing(fmt) && return println("Image saved to ", abspath(name))
+    dir = dirname(name)
+    println("Images saved to ", isempty(dir) ? pwd() : abspath(dir))
 end
 
 end # module

--- a/ext/WaterLilyMakieExt.jl
+++ b/ext/WaterLilyMakieExt.jl
@@ -129,15 +129,13 @@ Keyword arguments:
     - `body2mesh::Bool`: The body is plotted by generating a GeometryBasics.mesh, otherwise just as a Makie.volume (faster).
         Note that Meshing and GeometryBasics packages must be loaded if `body2mesh=true`.
     - `body_color`: Body color, can also containt alpha value, eg (:black, 0.9)
-    - `video::String`: Save the simulation as a video to this path instead of rendering interactively. Parent directories are
-        created as needed and the saved path is printed. Defaults to `nothing` (not saving video).
+    - `video::String`: Save the simulation as a video to this path instead of rendering interactively. Defaults to `nothing` (not saving video).
     - `img`: Save rendered frame(s) as image file(s). Pass a filename `String` with a `.png` extension to save with the
         active backend, e.g. `img="frame.png"`. To save a `.svg` or `.pdf`, pass a `(name, backend)` tuple where `backend` is a
-        loaded Makie backend that supports vector output (CairoMakie), e.g. `img=("frame.svg", CairoMakie)`; passing a `.svg`/`.pdf`
-        name without a backend errors. If `name` contains a printf integer placeholder (e.g. `img="frame_%04d.png"` or
-        `img=("frame_%04d.svg", CairoMakie)`), one image is saved per simulation frame (like `video`, rendered offscreen with no
-        interactive window); otherwise only the last rendered frame is saved. Parent directories are created as needed, and the
-        saved path (single image) or parent directory (series) is printed. Can be combined with `video`. Defaults to `nothing`.
+        loaded Makie backend that supports vector output (CairoMakie) (eg. `img=("frame.svg", CairoMakie)`).
+        If `name` contains a printf integer placeholder (e.g. `img="frame_%04d.png"` or `img=("frame_%04d.svg", CairoMakie)`),
+        one image is saved per simulation frame (like `video`, rendered offscreen with no interactive window); otherwise only the last frame is saved.
+        Can be combined with `video`. Defaults to `nothing`.
     - `hidedecorations::Bool`: Figures without axis details.
     - `azimuth::Number`: Camera azimuth angle. Find a suitable angle interactively checking `ax.azimuth.val`
     - `elevation::Number`: Camera elevation angle. Find a suitable angle interactively checking `ax.elevation.val`.
@@ -315,13 +313,11 @@ end
     parse_img(img)
 
 Validate and unpack the `img` image-saving spec into `(name, backend, fmt)`. `img` is either a filename `String`
-(saved with the active backend, must be `.png`) or a `(name, backend)` tuple (the backend must support the requested
-extension, e.g. CairoMakie for `.svg`/`.pdf`). If `name` contains a printf integer placeholder (eg. `frame_%04d.png`),
-`fmt` is a `Printf.Format` and one image is saved per simulation frame; otherwise `fmt` is `nothing` (single last frame).
-Returns `(nothing, nothing, nothing)` when `img === nothing`.
+(must be `.png`) or a `(name, backend)` tuple (the backend must support the requested extension, e.g. CairoMakie for `.svg`/`.pdf`)
+If `name` contains a printf integer placeholder (eg. `frame_%04d.png`), `fmt` is a `Printf.Format` and one image is saved per simulation frame.
 """
+parse_img(img::Nothing) = (nothing, nothing, nothing)
 function parse_img(img)
-    isnothing(img) && return nothing, nothing, nothing
     explicit_backend = img isa Tuple
     name, backend = explicit_backend ? (img[1], img[2]) : (img, Makie.current_backend())
     ext = lowercase(splitext(name)[2])
@@ -337,8 +333,8 @@ end
 Save `fig` to `name` with `backend`, creating the parent directory if needed. Returns the absolute path,
 or `nothing` (no-op) when `name === nothing`.
 """
+save_img(name::Nothing, backend, fig) = nothing
 function save_img(name, backend, fig)
-    isnothing(name) && return nothing
     dir = dirname(name); isempty(dir) || mkpath(dir)
     Makie.save(name, fig; backend)
     return abspath(name)
@@ -350,9 +346,9 @@ end
 Print where image output landed: a single image (`fmt === nothing`) prints its absolute path; an image series
 prints its absolute parent directory. No-op when `name === nothing`.
 """
+report_img(name::Nothing, fmt::Nothing) = nothing
+report_img(name, fmt::Nothing) = println("Image saved to ", abspath(name))
 function report_img(name, fmt)
-    isnothing(name) && return
-    isnothing(fmt) && return println("Image saved to ", abspath(name))
     dir = dirname(name)
     println("Images saved to ", isempty(dir) ? pwd() : abspath(dir))
 end


### PR DESCRIPTION
## Summary

`viz!` could previously only save a `video`. This adds an `img` kwarg to also save **still image(s)** of the rendered frame(s).

| Form | Result |
|---|---|
| `img="frame.png"` | last frame, saved with the **active** Makie backend |
| `img=("frame.svg", CairoMakie)` | last frame as `.svg`/`.pdf` via an explicit backend |
| `img="frame_%04d.png"` | **one image per simulation frame** (ffmpeg-style index), like `video` |
| `img=("frame_%04d.svg", CairoMakie)` | per-frame vector sequence |

Details:
- Supported extensions: `.png`, `.svg`, `.pdf`. A bare-string `.svg`/`.pdf` (no backend) errors, since only `.png` is backend-agnostic; `.svg`/`.pdf` require a backend passed as a `(name, backend)` tuple (e.g. CairoMakie). The backend is *passed* to `Makie.save(...; backend)`, so it need not be the active one.
- A `%` printf placeholder in the name switches from "last frame" to "one file per `step`". An **image series renders offscreen** (no interactive window opens, matching `video`).
- Parent directories are created as needed for both `img` and `video`, and the destination is printed: the file path for a single image, the parent directory for a series, and the path for a video.

## Implementation
- New `img` kwarg on `viz!`, plus helpers `parse_img` (validate/unpack `(name, backend, fmt)`), `save_img` (save + `mkpath`), and `report_img` (print destination).
- `Printf` added to the extension imports for the `%`-pattern frame numbering.

## Testing
Exercised against the real `viz!` over a small simulation:
- single PNG (active backend) and single SVG/PDF (tuple)
- PNG and SVG sequences (zero-padded, into auto-created subdirs)
- GLMakie series confirmed to render offscreen (no window)
- video into a non-existent directory (dir created, path printed)
- error cases: bare-string `.svg`, unsupported extension
- relative paths with directory components (no mangling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)