### PR TITLE
TagBot: grant contents:write so releases can be created

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -4,6 +4,10 @@ on:
     types:
       - created
   workflow_dispatch:
+permissions:
+  contents: write       # create the GitHub release (and tag)
+  issues: write         # read closed issues for the changelog; open an issue if TagBot fails
+  pull-requests: read   # read merged PRs for the changelog
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'


### PR DESCRIPTION
TagBot's release creation failed for v1.8.0 with `403 Resource not accessible by integration` ([run](https://github.com/WaterLily-jl/WaterLily.jl/actions/runs/28240237717)). The tag was still pushed (via the SSH key), but no GitHub release was created.

Cause: the org-enforced default `GITHUB_TOKEN` permission is read-only, so `POST /releases` is forbidden (`x-accepted-github-permissions: contents=write`).

Fix: add an explicit `permissions:` block granting `contents: write`. Because listing any permission sets all others to `none`, the issue/PR reads TagBot needs for the changelog are granted explicitly too. This mirrors how [CUDA.jl's TagBot](https://github.com/JuliaGPU/CUDA.jl/blob/main/.github/workflows/TagBot.yml) handles the same situation.

Only affects future version releases; v1.8.0 is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)