### PR TITLE
Collapse rate-of-strain S into one dimension-agnostic method

### DIFF
--- a/src/Metrics.jl
+++ b/src/Metrics.jl
@@ -112,8 +112,7 @@ end
 
 Rate-of-strain tensor.
 """
-S(I::CartesianIndex{2},u) = @SMatrix [0.5*(∂(i,j,I,u)+∂(j,i,I,u)) for i ∈ 1:2, j ∈ 1:2]
-S(I::CartesianIndex{3},u) = @SMatrix [0.5*(∂(i,j,I,u)+∂(j,i,I,u)) for i ∈ 1:3, j ∈ 1:3]
+@inline S(I::CartesianIndex{D},u) where D = SMatrix{D,D}((∂(i,j,I,u)+∂(j,i,I,u))/2 for i ∈ 1:D, j ∈ 1:D)
 
 """
     viscous_force(sim::Simulation)


### PR DESCRIPTION
## Summary

Simplifies `S(I,u)` (rate-of-strain tensor) in `src/Metrics.jl` from two hardcoded-dimension methods into a single generic method, and fixes a Float32→Float64 widening that hurts GPU performance.

```julia
# before
S(I::CartesianIndex{2},u) = @SMatrix [0.5*(∂(i,j,I,u)+∂(j,i,I,u)) for i ∈ 1:2, j ∈ 1:2]
S(I::CartesianIndex{3},u) = @SMatrix [0.5*(∂(i,j,I,u)+∂(j,i,I,u)) for i ∈ 1:3, j ∈ 1:3]

# after
@inline S(I::CartesianIndex{D},u) where D = SMatrix{D,D}((∂(i,j,I,u)+∂(j,i,I,u))/2 for i ∈ 1:D, j ∈ 1:D)
```

## Why

- **One method instead of two.** The duplicated 2D/3D methods existed only because `@SMatrix`'s comprehension needs literal ranges at macro-expansion time, so the dimension `D` couldn't drive the matrix size. Passing a generator to the `SMatrix{D,D}(...)` constructor sidesteps that (it routes through `sacollect`) and produces a fully-unrolled, type-stable `SMatrix`. The generator iterates `i` fastest, matching `@SMatrix`'s column-major fill, so the index mapping is **identical** to the originals.
- **`0.5*(…)` → `(…)/2`.** The `0.5` literal is `Float64`, so `0.5*(Float32…)` silently widens every tensor entry to `Float64`. Harmless on CPU, but throttles GPU kernels for a `Float32` field. `/2` preserves `eltype(u)` and matches the `/2` already used in `λ₂` just above. This is bit-identical for the test inputs (`2·(x/2) == x` exactly for powers of two).

## Testing

`julia --project -e 'using Pkg; Pkg.test(test_args=["metrics"])'` — all 38 metrics tests pass (the existing `test/test_metrics.jl` stress-tensor block exercises both 2D and 3D `S` for zero, uniform-gradient, and shear fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)