### PR TITLE
MultiLevelPoisson: make `smooth!` const to stop per-V-cycle allocations

### DIFF
--- a/src/MultiLevelPoisson.jl
+++ b/src/MultiLevelPoisson.jl
@@ -103,7 +103,7 @@ end
 mult!(ml::MultiLevelPoisson,x) = mult!(ml.levels[1],x)
 residual!(ml::MultiLevelPoisson,x) = residual!(ml.levels[1],x)
 
-smooth! = GaussSeidelRB!
+const smooth! = GaussSeidelRB!
 
 function solver!(ml::MultiLevelPoisson{T};tol=1e-4,itmx=32) where T
     p = ml.levels[1]

--- a/test/test_alloc.jl
+++ b/test/test_alloc.jl
@@ -54,3 +54,25 @@ backend != "SIMD" && throw(ArgumentError("KernelAbstractions backend not allowed
         @test r.memory < 50000 # AbstractFlow dispatch must not allocate more than concrete Flow
     end
 end
+
+@testset "semi-coarsening + remeasure allocations" begin
+    # Non-square (4:1) domain + moving body: exercises semi-coarsening and the per-step remeasure
+    # path through the multigrid V-cycle. Tight bound to catch per-V-cycle boxing (clean ≈ 0.45 KiB).
+    function SimAniso(θ; L=32, U=1, Re=100)
+        function map(x,t)
+            s,c = sincos(θ + t*U/L)
+            SA[c -s; s c]*(x-SA[2L,L])
+        end
+        function sdf(ξ,t)
+            p = ξ-SA[0,clamp(ξ[1],-L,L)]
+            √(p'*p)-2
+        end
+        Simulation((20L,5L),(U,0),L,ν=U*L/Re,body=AutoBody(sdf,map),T=Float32)
+    end
+    sim = SimAniso(Float32(π/36))
+    sim_step!(sim)
+    b = @benchmarkable sim_step!($sim; remeasure=true) samples=100; tune!(b) # full step incl. remeasure
+    r = run(b)
+    println("▶ Allocated (aniso sim_step! remeasure) "*@sprintf("%.2f", r.memory/1e3)*" KiB")
+    @test r.memory < 1000 # less than 1 KiB; ~0.45 KiB clean, ~2 KiB if a V-cycle call boxes
+end


### PR DESCRIPTION
### Summary

`smooth! = GaussSeidelRB!` is a non-`const` global binding, so every `smooth!(...)` call in `Vcycle!`/`solver!` is a dynamic dispatch that boxes its result. That allocates ~0.5 KiB per V-cycle, scaling with the number of multigrid levels and the (flow-state-dependent) V-cycle count. Marking it `const` lets the dispatch resolve statically and removes the allocation.

This surfaced while investigating why the benchmark allocation column wasn't steady between runs/versions: per-step allocation was tracking the V-cycle count through this dispatch.

### Effect (SIMD, single thread)

| | before | after |
|---|---|---|
| `Vcycle!` (one cycle) | 576 B | **0 B** |
| `jelly` p5 `sim_step!` / 25 steps | 80128 B, scales with V-cycles | **13600 B, flat** |
| existing `mom_step!` alloc test | ~1.8 KiB | **~0 KiB** |

Behaviour-preserving: nothing reassigns `smooth!` anywhere in `src`/`test`/`ext`, and `const` only changes how the dispatch resolves, not which function runs.

### Test

Adds a `"semi-coarsening + remeasure"` allocation set: a non-square (4:1) domain with a moving body, asserting `sim_step!(remeasure=true) < 1 KiB`. This exercises the semi-coarsening and per-step remeasure paths through the V-cycle, which the existing checks (square domain, `mom_step!` only, 50 KiB ceiling) don't. Verified it fails (~2 KiB) on the non-`const` binding and passes (~0.45 KiB) with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)