### PR TITLE
JLD2 `load!`: copy host arrays into place, without a transient device copy

### DIFF
--- a/ext/WaterLilyJLD2Ext.jl
+++ b/ext/WaterLilyJLD2Ext.jl
@@ -40,9 +40,8 @@ function load!(flow::AbstractFlow; kwargs...)
     dir = get(Dict(kwargs), :dir, "./")
     obj = jldopen(joinpath(dir, fname))
     @assert size(flow.p) == size(obj["p"]) "Simulation size does not match the size of the JLD2-stored simulation."
-    f = typeof(flow.p).name.wrapper
-    flow.p .= obj["p"] |> f
-    flow.u .= obj["u"] |> f
+    copyto!(flow.p, obj["p"])  # host→device copy in place: no transient device array (cf. `.= x |> CuArray`)
+    copyto!(flow.u, obj["u"])
     empty!(flow.Δt)
     push!(flow.Δt, obj["Δt"]...)
     close(obj)
@@ -61,10 +60,9 @@ function load!(meanflow::MeanFlow; kwargs...)
     dir = get(Dict(kwargs), :dir, "./")
     obj = jldopen(joinpath(dir, fname))
     @assert size(meanflow.P) == size(obj["P"]) "Simulation size does not match the size of the JLD2-stored simulation."
-    f = typeof(meanflow.P).name.wrapper
-    meanflow.P .= obj["P"] |> f
-    meanflow.U .= obj["U"] |> f
-    isnothing(meanflow.UU) || (meanflow.UU .= obj["UU"] |> f)
+    copyto!(meanflow.P, obj["P"])  # host→device copy in place: no transient device array
+    copyto!(meanflow.U, obj["U"])
+    isnothing(meanflow.UU) || copyto!(meanflow.UU, obj["UU"])
     empty!(meanflow.t)
     push!(meanflow.t, obj["t"]...)
     close(obj)

--- a/ext/WaterLilyJLD2Ext.jl
+++ b/ext/WaterLilyJLD2Ext.jl
@@ -40,7 +40,7 @@ function load!(flow::AbstractFlow; kwargs...)
     dir = get(Dict(kwargs), :dir, "./")
     obj = jldopen(joinpath(dir, fname))
     @assert size(flow.p) == size(obj["p"]) "Simulation size does not match the size of the JLD2-stored simulation."
-    copyto!(flow.p, obj["p"])  # host→device copy in place: no transient device array (cf. `.= x |> CuArray`)
+    copyto!(flow.p, obj["p"])
     copyto!(flow.u, obj["u"])
     empty!(flow.Δt)
     push!(flow.Δt, obj["Δt"]...)
@@ -60,7 +60,7 @@ function load!(meanflow::MeanFlow; kwargs...)
     dir = get(Dict(kwargs), :dir, "./")
     obj = jldopen(joinpath(dir, fname))
     @assert size(meanflow.P) == size(obj["P"]) "Simulation size does not match the size of the JLD2-stored simulation."
-    copyto!(meanflow.P, obj["P"])  # host→device copy in place: no transient device array
+    copyto!(meanflow.P, obj["P"])
     copyto!(meanflow.U, obj["U"])
     isnothing(meanflow.UU) || copyto!(meanflow.UU, obj["UU"])
     empty!(meanflow.t)


### PR DESCRIPTION
`load!` restored the flow/mean-flow arrays with `field .= obj[key] |> f` where f is the array wrapper (e.g. CuArray). On a GPU backend `obj[key] |> CuArray` allocates a full extra device copy of the field before the broadcast frees it, so restoring a state needs headroom for one more copy of u the fields.

Use `copyto!(field, obj[key])` instead: a direct host→device copy with no intermediate device allocation (and a plain memcpy on CPU backends). Behaviour is unchanged — verified a save/load round-trip restores p, u, and Δt bit-exactly on both CPU and GPU.

Assisted-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>