### PR TITLE
fix: false serial-thread warning during precompilation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -50,7 +50,7 @@ Preferences = "1.4"
 Reexport = "^1.2.2"
 Requires = "1.3"
 StaticArrays = "^1.1.0"
-julia = "1.10"
+julia = "1.11"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -199,9 +199,11 @@ export viz!, get_body, plot_body_obs!
     check_nthreads()
 
 Check the number of threads available for the Julia session that loads WaterLily.
+Called from `__init__`; skipped during package precompilation (which always runs with one thread).
 A warning is shown when running in serial (JULIA_NUM_THREADS=1) with KernelAbstractions enabled.
 """
 function check_nthreads()
+    Base.generating_output(true) && return nothing
     if backend == "KernelAbstractions" && Threads.nthreads() == 1
         @warn """
         Using WaterLily in serial (ie. JULIA_NUM_THREADS=1) is not recommended because it defaults to serial CPU execution.
@@ -209,7 +211,12 @@ function check_nthreads()
         For a low-overhead single-threaded CPU only backend set: WaterLily.set_backend("SIMD")
         """
     end
+    return nothing
 end
-check_nthreads()
+
+function __init__()
+    check_nthreads()
+    return nothing
+end
 
 end # module

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -203,7 +203,7 @@ Called from `__init__`; skipped during package precompilation (which always runs
 A warning is shown when running in serial (JULIA_NUM_THREADS=1) with KernelAbstractions enabled.
 """
 function check_nthreads()
-    Base.generating_output(true) && return nothing
+    Base.generating_output() && return nothing
     if backend == "KernelAbstractions" && Threads.nthreads() == 1
         @warn """
         Using WaterLily in serial (ie. JULIA_NUM_THREADS=1) is not recommended because it defaults to serial CPU execution.
@@ -211,12 +211,8 @@ function check_nthreads()
         For a low-overhead single-threaded CPU only backend set: WaterLily.set_backend("SIMD")
         """
     end
-    return nothing
 end
 
-function __init__()
-    check_nthreads()
-    return nothing
-end
-
+__init__() = check_nthreads()
+    
 end # module


### PR DESCRIPTION
WL emits the serial execution warning during precompilation, which afaik always runs with 1 thread, which is a false positive.

This moves `check_nthreads` to `__init__` so it runs on actual package load with the user's thread count, and skip it while generating precompile output.