### PR TITLE
Change print in `sim_info` to use formatted string instead of round and digits

### DIFF
--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -152,7 +152,7 @@ end
     sim_info(sim::AbstractSimulation)
 Prints information on the current state of a simulation.
 """
-sim_info(sim::AbstractSimulation) = println("tU/L=",round(sim_time(sim),digits=4),", Δt=",round(sim.flow.Δt[end],digits=3))
+sim_info(sim::AbstractSimulation) = @printf "tU/L=%.4f, Δt=%.3f\n" sim_time(sim) sim.flow.Δt[end]
 
 """
     perturb!(sim; noise=0.1)

--- a/src/WaterLily.jl
+++ b/src/WaterLily.jl
@@ -3,7 +3,7 @@ $(README)
 """
 module WaterLily
 
-using DocStringExtensions
+using DocStringExtensions, Printf
 
 abstract type AbstractSimulation end
 


### PR DESCRIPTION
Cuts print cost by 4x, and tiny allocations reduction as well. Probably insignificant, but why not.

```sh
# master
sim_info(sim::AbstractSimulation) = println("tU/L=",round(sim_time(sim),digits=4),", Δt=",round(sim.flow.Δt[end],digits=3))
#=
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  13.782 μs …  66.729 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     16.226 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   16.293 μs ± 753.933 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                            ▂▆██▆▄▁
  ▂▁▂▂▂▁▁▂▁▁▂▁▁▁▁▂▁▁▂▂▂▂▃▅▆████████▇▅▄▃▃▂▂▂▂▂▂▂▂▂▂▁▂▁▂▂▂▂▂▂▂▂▂ ▃
  13.8 μs         Histogram: frequency by time         18.8 μs <

 Memory estimate: 1.22 KiB, allocs estimate: 26.
=#

# fix
# sim_info(sim::AbstractSimulation) = @printf "tU/L=%.4f, Δt=%.3f\n" sim_time(sim) sim.flow.Δt[end]
#=
BenchmarkTools.Trial: 10000 samples with 8 evaluations per sample.
 Range (min … max):  2.841 μs … 320.178 μs  ┊ GC (min … max): 0.00% … 96.98%
 Time  (median):     3.317 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.461 μs ±   6.012 μs  ┊ GC (mean ± σ):  3.38% ±  1.93%

                   ▃▇█▇▄
  ▂▂▂▂▂▂▂▁▂▂▁▂▂▂▃▄▇█████▇▅▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▃
  2.84 μs         Histogram: frequency by time        4.26 μs <
=#
```